### PR TITLE
refactor: remove unused message module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,0 @@
-mod messages;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,9 +1,0 @@
-trait Message {}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_parses_discovery_message_successfully() {}
-}


### PR DESCRIPTION
## Summary
- remove the unused private `messages` module
- delete the empty placeholder test that only exercised the unused module

## Verification
- `cargo test`

## Notes
- `cargo fmt --check` could not run because `cargo-fmt` is not installed in this environment.
- `cargo clippy --all-targets --all-features -- -D warnings` could not run because `clippy` is not installed in this environment.