### PR TITLE
refactor: remove cargo boilerplate comment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,4 @@ name = "decentra-chat"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]


### PR DESCRIPTION
## Summary
- remove the generated Cargo manifest boilerplate comment
- keep `Cargo.toml` focused on project-specific metadata

## Verification
- `cargo test`

## Notes
- `cargo test` passes with existing warnings from `src/messages.rs` on `main`.
- `cargo fmt --check` could not run because `cargo-fmt` is not installed in this environment.
- `cargo clippy --all-targets --all-features -- -D warnings` could not run because `clippy` is not installed in this environment.