### PR TITLE
refactor: remove duplicate target ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,3 @@ Cargo.lock
 
 
 # Added by cargo
-
-/target


### PR DESCRIPTION
## Summary
- remove the duplicate `/target` entry from `.gitignore`
- keep the existing `/target/` Cargo ignore pattern, so ignored files are unchanged

## Verification
- `cargo test`

## Notes
- `cargo test` passes with existing warnings from `src/messages.rs` on `main`.
- `cargo fmt --check` could not run because `cargo-fmt` is not installed in this environment.
- `cargo clippy --all-targets --all-features -- -D warnings` could not run because `clippy` is not installed in this environment.