### PR TITLE
docs: update README with project overview, build instructions, and quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
-# decentra-chat
-A true decentralized chat for people, by people.
+# DecentraChat
 
-Hello ! this is still being crafted. We recommend to:
+![](https://img.shields.io/static/v1?label=Status&message=Early+development+%E2%80%94+v0.1+in+progress&color=orange)
 
-1. Read the proposal [here](PAPER.md)
+DecentraChat is a serverless, peer-to-peer chat application that uses PGP encryption over LAN multicast. There is no central server: peers discover each other on the local network and exchange end-to-end encrypted, cryptographically signed messages. It is designed for privacy-conscious users, air-gapped networks, and settings like conferences or events where participants share a local network.
+
+## Prerequisites
+
+- Rust stable toolchain — install via [rustup.rs](https://rustup.rs)
+
+## Build
+
+```sh
+cargo build
+```
+
+## Test
+
+```sh
+cargo test
+```
+
+## Quickstart
+
+> TODO: coming in v0.1 — run two instances on the same LAN and they will discover each other automatically via IP multicast.
+
+## Protocol specification
+
+The full protocol design — peer discovery, key exchange, message format, acknowledgement, and ordering — is documented in [PAPER.md](PAPER.md).
+
+## Contributing
+
+A contributor guide is in progress. See [CONTRIBUTING.md](CONTRIBUTING.md) once it lands.


### PR DESCRIPTION
## Summary

- Replace the stub README with a proper front door covering what DecentraChat is, who it is for, and how to get started
- Add a status badge noting early development / v0.1 in progress
- Add copy-pasteable `cargo build` and `cargo test` instructions with prerequisites (Rust stable via rustup)
- Add a quickstart stub marked `TODO: coming in v0.1` since the binary is not yet functional
- Link to `PAPER.md` for the full protocol specification
- Link to `CONTRIBUTING.md` with a note that the contributor guide is in progress

Closes #11

## Verification

- `cargo build` and `cargo test` work on a clean checkout of main (no external dependencies in `Cargo.toml` at this stage)
- All links in the README resolve: `PAPER.md` exists, `CONTRIBUTING.md` is noted as coming
- Status badge renders via shields.io (same service already used in `PAPER.md`)

## Acceptance criteria coverage

- [x] What it is (2-3 sentences, P2P/PGP/LAN multicast, target audience)
- [x] Status badge/note
- [x] Build instructions (prerequisites, `cargo build`, `cargo test`)
- [x] Quickstart stub with `TODO: coming in v0.1`
- [x] Link to `PAPER.md`
- [x] Link to `CONTRIBUTING.md` with coming-soon note

🤖 Generated with [Claude Code](https://claude.ai/claude-code)