### PR TITLE
feat: message ACK handling and persistence

### DIFF
--- a/src/message_transport.rs
+++ b/src/message_transport.rs
@@ -1,7 +1,8 @@
 use crate::{
-    codec::{self, ChatMessage, Message},
+    codec::{self, ChatMessage, Message, MessageAck},
     crypto,
     discovery::Fingerprint,
+    storage::{MessageAckUpsert, Storage, StorageError},
 };
 use pgp::composed::{SignedPublicKey, SignedSecretKey};
 use rand::RngCore;
@@ -59,6 +60,15 @@ pub struct ReceivedChatMessage {
     pub message_hash: [u8; 32],
 }
 
+/// Accepted type-5 ACK after signature validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReceivedMessageAck {
+    pub message_uuid: [u8; 16],
+    pub message_hash: [u8; 32],
+    pub acknowledger: Fingerprint,
+    pub signature: Vec<u8>,
+}
+
 /// Running TCP receiver for encrypted signed type-4 messages.
 pub struct ChatMessageService {
     local_addr: SocketAddr,
@@ -97,6 +107,8 @@ pub enum ChatTransportError {
     UnexpectedMessage { received: &'static str },
     #[error("chat message version {version} is unsupported")]
     UnsupportedVersion { version: u8 },
+    #[error("message ACK version {version} is unsupported")]
+    UnsupportedAckVersion { version: u8 },
     #[error("chat message conversation type {conv_type} is unsupported")]
     UnsupportedConversationType { conv_type: u8 },
     #[error("chat message id is not a UUID v4")]
@@ -109,16 +121,26 @@ pub enum ChatTransportError {
     SourceMismatch,
     #[error("chat message destination fingerprint did not match local identity")]
     DestinationMismatch,
+    #[error("message ACK uuid did not match the sent message uuid")]
+    AckMessageUuidMismatch,
+    #[error("message ACK hash did not match the sent message hash")]
+    AckMessageHashMismatch,
+    #[error("message ACK acknowledger did not match expected peer")]
+    AckAcknowledgerMismatch,
     #[error("chat message timestamp is outside the accepted window")]
     TimestampOutOfWindow,
     #[error("chat headers are too large: {len} bytes, max 65535")]
     HeadersTooLarge { len: usize },
     #[error("chat message signature verification failed: {0}")]
     Signature(#[source] crypto::CryptoError),
+    #[error("message ACK signature verification failed: {0}")]
+    AckSignature(#[source] crypto::CryptoError),
     #[error("chat payload encryption failed: {0}")]
     Encrypt(#[source] crypto::CryptoError),
     #[error("chat payload decryption failed: {0}")]
     Decrypt(#[source] crypto::CryptoError),
+    #[error("failed to persist message ACK state: {0}")]
+    Storage(#[source] StorageError),
     #[error("system clock is before the Unix epoch")]
     InvalidSystemTime,
 }
@@ -178,6 +200,38 @@ pub async fn send_chat_message(
     peer: &PeerChatIdentity,
     outgoing: OutgoingChatMessage,
 ) -> Result<ChatMessage, ChatTransportError> {
+    let (message, _ack) = send_chat_message_with_ack(peer_addr, local, peer, outgoing).await?;
+    Ok(message)
+}
+
+/// Build, encrypt, sign, send one type-4 chat message, and persist its type-5 ACK.
+pub async fn send_chat_message_and_record_ack(
+    peer_addr: SocketAddr,
+    local: &LocalChatIdentity,
+    peer: &PeerChatIdentity,
+    outgoing: OutgoingChatMessage,
+    storage: &Storage,
+) -> Result<(ChatMessage, ReceivedMessageAck), ChatTransportError> {
+    let (message, ack) = send_chat_message_with_ack(peer_addr, local, peer, outgoing).await?;
+    storage
+        .upsert_message_ack(MessageAckUpsert {
+            message_uuid: ack.message_uuid,
+            message_hash: ack.message_hash,
+            acknowledger: ack.acknowledger,
+            signature: ack.signature.clone(),
+        })
+        .map_err(ChatTransportError::Storage)?;
+
+    Ok((message, ack))
+}
+
+/// Build, encrypt, sign, send one type-4 chat message, and wait for its type-5 ACK.
+pub async fn send_chat_message_with_ack(
+    peer_addr: SocketAddr,
+    local: &LocalChatIdentity,
+    peer: &PeerChatIdentity,
+    outgoing: OutgoingChatMessage,
+) -> Result<(ChatMessage, ReceivedMessageAck), ChatTransportError> {
     let message = build_chat_message(local, peer, outgoing)?;
     let mut stream = TcpStream::connect(peer_addr)
         .await
@@ -187,7 +241,8 @@ pub async fn send_chat_message(
         })?;
 
     write_message(&mut stream, Message::ChatMessage(message.clone())).await?;
-    Ok(message)
+    let ack = read_message_ack(&mut stream, &message, peer).await?;
+    Ok((message, ack))
 }
 
 /// Verify, decrypt, and hash a received type-4 chat message.
@@ -300,7 +355,11 @@ async fn handle_connection(
         });
     };
 
-    accept_chat_message(message, local, peer, expected_previous_hash)
+    let accepted = accept_chat_message(message, local, peer, expected_previous_hash)?;
+    let ack = build_message_ack(&accepted, local)?;
+    write_message(&mut stream, Message::MessageAck(ack)).await?;
+
+    Ok(accepted)
 }
 
 fn validate_chat_message(
@@ -359,6 +418,95 @@ fn chat_message_signed_bytes(message: &ChatMessage) -> Vec<u8> {
 
 fn chat_message_signature_digest(message: &ChatMessage) -> [u8; 32] {
     Sha256::digest(chat_message_signed_bytes(message)).into()
+}
+
+fn build_message_ack(
+    message: &ReceivedChatMessage,
+    local: &LocalChatIdentity,
+) -> Result<MessageAck, ChatTransportError> {
+    let mut ack = MessageAck {
+        version: WIRE_CHAT_VERSION,
+        uuid: message.uuid,
+        message_hash: message.message_hash,
+        acknowledger: local.fingerprint,
+        signature: Vec::new(),
+    };
+    let signature_digest = message_ack_signature_digest(&ack);
+    ack.signature = crypto::sign(&local.secret_key, &signature_digest)
+        .map_err(ChatTransportError::AckSignature)?;
+
+    Ok(ack)
+}
+
+async fn read_message_ack(
+    stream: &mut TcpStream,
+    sent: &ChatMessage,
+    peer: &PeerChatIdentity,
+) -> Result<ReceivedMessageAck, ChatTransportError> {
+    let message = read_message(stream).await?;
+    let Message::MessageAck(ack) = message else {
+        return Err(ChatTransportError::UnexpectedMessage {
+            received: message_name(&message),
+        });
+    };
+
+    accept_message_ack(ack, sent, peer)
+}
+
+fn accept_message_ack(
+    ack: MessageAck,
+    sent: &ChatMessage,
+    peer: &PeerChatIdentity,
+) -> Result<ReceivedMessageAck, ChatTransportError> {
+    let expected_hash = Sha256::digest(Vec::<u8>::from(sent.clone())).into();
+    validate_message_ack(&ack, sent.uuid, expected_hash, peer)?;
+
+    let signature_digest = message_ack_signature_digest(&ack);
+    crypto::verify(&peer.public_key, &signature_digest, &ack.signature)
+        .map_err(ChatTransportError::AckSignature)?;
+
+    Ok(ReceivedMessageAck {
+        message_uuid: ack.uuid,
+        message_hash: ack.message_hash,
+        acknowledger: ack.acknowledger,
+        signature: ack.signature,
+    })
+}
+
+fn validate_message_ack(
+    ack: &MessageAck,
+    expected_uuid: [u8; 16],
+    expected_hash: [u8; 32],
+    peer: &PeerChatIdentity,
+) -> Result<(), ChatTransportError> {
+    if ack.version != WIRE_CHAT_VERSION {
+        return Err(ChatTransportError::UnsupportedAckVersion {
+            version: ack.version,
+        });
+    }
+    if ack.uuid != expected_uuid {
+        return Err(ChatTransportError::AckMessageUuidMismatch);
+    }
+    if ack.message_hash != expected_hash {
+        return Err(ChatTransportError::AckMessageHashMismatch);
+    }
+    if ack.acknowledger != peer.fingerprint {
+        return Err(ChatTransportError::AckAcknowledgerMismatch);
+    }
+    Ok(())
+}
+
+fn message_ack_signed_bytes(ack: &MessageAck) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push(ack.version);
+    out.extend_from_slice(&ack.uuid);
+    out.extend_from_slice(&ack.message_hash);
+    out.extend_from_slice(&ack.acknowledger);
+    out
+}
+
+fn message_ack_signature_digest(ack: &MessageAck) -> [u8; 32] {
+    Sha256::digest(message_ack_signed_bytes(ack)).into()
 }
 
 async fn read_message(stream: &mut TcpStream) -> Result<Message, ChatTransportError> {
@@ -465,6 +613,7 @@ fn message_name(message: &Message) -> &'static str {
 mod tests {
     use super::*;
     use crate::crypto::{fingerprint, public_key_to_bytes, KeyPair};
+    use crate::storage::Storage;
     use std::net::{IpAddr, Ipv4Addr};
     use tokio::time::{timeout, Duration};
 
@@ -548,6 +697,83 @@ mod tests {
         assert_eq!(received.headers, b"Content-Type: text/plain");
         assert_eq!(received.plaintext, b"hello bob");
         assert_ne!(sent.data, b"hello bob");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn loopback_sender_receives_and_persists_message_ack() {
+        let (alice_local, bob_peer, bob_local, alice_peer) = identities();
+        let previous_hash = [0x62; 32];
+        let mut receiver = ChatMessageService::start(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            bob_local,
+            alice_peer,
+            previous_hash,
+        )
+        .await
+        .expect("start chat receiver");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = Storage::open(dir.path().join("dc.sqlite3")).expect("open storage");
+
+        let (sent, ack) = send_chat_message_and_record_ack(
+            receiver.local_addr(),
+            &alice_local,
+            &bob_peer,
+            OutgoingChatMessage {
+                conversation_uuid: uuid_v4(0x31),
+                previous_hash,
+                headers: b"Content-Type: text/plain".to_vec(),
+                plaintext: b"ack me".to_vec(),
+            },
+            &storage,
+        )
+        .await
+        .expect("send chat message and record ack");
+
+        let received = timeout(Duration::from_secs(10), receiver.recv())
+            .await
+            .expect("receive should finish")
+            .expect("accepted message");
+        let stored = storage
+            .get_message_ack(sent.uuid)
+            .expect("fetch stored ack")
+            .expect("ack persisted");
+
+        assert_eq!(received.uuid, sent.uuid);
+        assert_eq!(ack.message_uuid, sent.uuid);
+        assert_eq!(ack.message_hash, received.message_hash);
+        assert_eq!(ack.acknowledger, bob_peer.fingerprint);
+        assert_eq!(stored.message_uuid, sent.uuid);
+        assert_eq!(stored.message_hash, ack.message_hash);
+        assert_eq!(stored.acknowledger, bob_peer.fingerprint);
+        assert_eq!(stored.signature, ack.signature);
+    }
+
+    #[test]
+    fn ack_with_wrong_message_uuid_is_rejected() {
+        let (alice_local, bob_peer, _bob_local, _alice_peer) = identities();
+        let sent = build_chat_message(
+            &alice_local,
+            &bob_peer,
+            OutgoingChatMessage {
+                conversation_uuid: uuid_v4(0x43),
+                previous_hash: [0x44; 32],
+                headers: Vec::new(),
+                plaintext: b"ack mismatch".to_vec(),
+            },
+        )
+        .expect("build message");
+        let ack = MessageAck {
+            version: WIRE_CHAT_VERSION,
+            uuid: uuid_v4(0x45),
+            message_hash: Sha256::digest(Vec::<u8>::from(sent.clone())).into(),
+            acknowledger: bob_peer.fingerprint,
+            signature: vec![1, 2, 3],
+        };
+
+        let error = accept_message_ack(ack, &sent, &bob_peer)
+            .expect_err("wrong ack uuid should be rejected");
+
+        assert!(matches!(error, ChatTransportError::AckMessageUuidMismatch));
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,6 +8,7 @@ use std::{
 use thiserror::Error;
 
 const MIGRATION_001: &str = "001_peer_keys";
+const MIGRATION_002: &str = "002_message_acks";
 
 /// SQLite-backed local storage for DecentraChat peer data.
 pub struct Storage {
@@ -34,6 +35,25 @@ pub struct PeerKeyUpsert {
     pub last_seen: i64,
 }
 
+/// Persisted delivery acknowledgement for one outbound chat message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageAckRecord {
+    pub message_uuid: [u8; 16],
+    pub message_hash: [u8; 32],
+    pub acknowledger: Fingerprint,
+    pub signature: Vec<u8>,
+    pub acknowledged_at: i64,
+}
+
+/// Data accepted by the ACK repository upsert operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageAckUpsert {
+    pub message_uuid: [u8; 16],
+    pub message_hash: [u8; 32],
+    pub acknowledger: Fingerprint,
+    pub signature: Vec<u8>,
+}
+
 /// Errors returned by SQLite storage initialization and repository operations.
 #[derive(Debug, Error)]
 pub enum StorageError {
@@ -55,6 +75,12 @@ pub enum StorageError {
     Repository(#[source] rusqlite::Error),
     #[error("peer public key must not be empty")]
     EmptyPublicKey,
+    #[error("message ACK signature must not be empty")]
+    EmptyAckSignature,
+    #[error("stored message UUID must be 16 bytes, got {len}")]
+    InvalidMessageUuidLength { len: usize },
+    #[error("stored message hash must be 32 bytes, got {len}")]
+    InvalidMessageHashLength { len: usize },
     #[error("stored peer fingerprint must be 32 bytes, got {len}")]
     InvalidFingerprintLength { len: usize },
     #[error("system clock is before the Unix epoch")]
@@ -136,6 +162,59 @@ impl Storage {
             .map(validate_record)
             .transpose()
     }
+
+    /// Insert or update the signed ACK state for an outbound message UUID.
+    pub fn upsert_message_ack(
+        &self,
+        upsert: MessageAckUpsert,
+    ) -> Result<MessageAckRecord, StorageError> {
+        if upsert.signature.is_empty() {
+            return Err(StorageError::EmptyAckSignature);
+        }
+
+        let acknowledged_at = unix_timestamp()?;
+        self.connection
+            .execute(
+                "INSERT INTO message_acks (
+                    message_uuid, message_hash, acknowledger, signature, acknowledged_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5)
+                ON CONFLICT(message_uuid) DO UPDATE SET
+                    message_hash = excluded.message_hash,
+                    acknowledger = excluded.acknowledger,
+                    signature = excluded.signature,
+                    acknowledged_at = excluded.acknowledged_at",
+                params![
+                    &upsert.message_uuid[..],
+                    &upsert.message_hash[..],
+                    &upsert.acknowledger[..],
+                    upsert.signature,
+                    acknowledged_at,
+                ],
+            )
+            .map_err(StorageError::Repository)?;
+
+        self.get_message_ack(upsert.message_uuid)?
+            .ok_or_else(|| StorageError::Repository(rusqlite::Error::QueryReturnedNoRows))
+    }
+
+    /// Fetch persisted ACK delivery state by the acknowledged message UUID.
+    pub fn get_message_ack(
+        &self,
+        message_uuid: [u8; 16],
+    ) -> Result<Option<MessageAckRecord>, StorageError> {
+        self.connection
+            .query_row(
+                "SELECT message_uuid, message_hash, acknowledger, signature, acknowledged_at
+                 FROM message_acks
+                 WHERE message_uuid = ?1",
+                params![&message_uuid[..]],
+                row_to_message_ack,
+            )
+            .optional()
+            .map_err(StorageError::Repository)?
+            .map(validate_ack_record)
+            .transpose()
+    }
 }
 
 fn apply_migrations(connection: &mut Connection) -> Result<(), StorageError> {
@@ -158,16 +237,30 @@ fn apply_migrations(connection: &mut Connection) -> Result<(), StorageError> {
             );
 
             CREATE INDEX IF NOT EXISTS idx_peer_keys_last_seen
-                ON peer_keys(last_seen);",
+                ON peer_keys(last_seen);
+
+            CREATE TABLE IF NOT EXISTS message_acks (
+                message_uuid BLOB PRIMARY KEY CHECK(length(message_uuid) = 16),
+                message_hash BLOB NOT NULL CHECK(length(message_hash) = 32),
+                acknowledger BLOB NOT NULL CHECK(length(acknowledger) = 32),
+                signature BLOB NOT NULL CHECK(length(signature) > 0),
+                acknowledged_at INTEGER NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_message_acks_acknowledger
+                ON message_acks(acknowledger);",
         )
         .map_err(StorageError::Migration)?;
 
-    transaction
-        .execute(
-            "INSERT OR IGNORE INTO schema_migrations (name, applied_at) VALUES (?1, ?2)",
-            params![MIGRATION_001, unix_timestamp()?],
-        )
-        .map_err(StorageError::Migration)?;
+    let now = unix_timestamp()?;
+    for migration in [MIGRATION_001, MIGRATION_002] {
+        transaction
+            .execute(
+                "INSERT OR IGNORE INTO schema_migrations (name, applied_at) VALUES (?1, ?2)",
+                params![migration, now],
+            )
+            .map_err(StorageError::Migration)?;
+    }
 
     transaction.commit().map_err(StorageError::Migration)
 }
@@ -189,11 +282,58 @@ fn row_to_peer_key(row: &rusqlite::Row<'_>) -> rusqlite::Result<PeerKeyRecord> {
     })
 }
 
+fn row_to_message_ack(row: &rusqlite::Row<'_>) -> rusqlite::Result<MessageAckRecord> {
+    Ok(MessageAckRecord {
+        message_uuid: vec_to_message_uuid(row.get(0)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                16,
+                rusqlite::types::Type::Blob,
+                Box::new(error),
+            )
+        })?,
+        message_hash: vec_to_message_hash(row.get(1)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                32,
+                rusqlite::types::Type::Blob,
+                Box::new(error),
+            )
+        })?,
+        acknowledger: vec_to_fingerprint(row.get(2)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                32,
+                rusqlite::types::Type::Blob,
+                Box::new(error),
+            )
+        })?,
+        signature: row.get(3)?,
+        acknowledged_at: row.get(4)?,
+    })
+}
+
 fn validate_record(record: PeerKeyRecord) -> Result<PeerKeyRecord, StorageError> {
     if record.public_key.is_empty() {
         return Err(StorageError::EmptyPublicKey);
     }
     Ok(record)
+}
+
+fn validate_ack_record(record: MessageAckRecord) -> Result<MessageAckRecord, StorageError> {
+    if record.signature.is_empty() {
+        return Err(StorageError::EmptyAckSignature);
+    }
+    Ok(record)
+}
+
+fn vec_to_message_uuid(bytes: Vec<u8>) -> Result<[u8; 16], StorageError> {
+    bytes.try_into().map_err(|bytes: Vec<u8>| {
+        StorageError::InvalidMessageUuidLength { len: bytes.len() }
+    })
+}
+
+fn vec_to_message_hash(bytes: Vec<u8>) -> Result<[u8; 32], StorageError> {
+    bytes.try_into().map_err(|bytes: Vec<u8>| {
+        StorageError::InvalidMessageHashLength { len: bytes.len() }
+    })
 }
 
 fn vec_to_fingerprint(bytes: Vec<u8>) -> Result<Fingerprint, StorageError> {
@@ -232,12 +372,13 @@ mod tests {
         let migration_count: i64 = storage
             .connection
             .query_row(
-                "SELECT COUNT(*) FROM schema_migrations WHERE name = ?1",
-                params![MIGRATION_001],
+                "SELECT COUNT(*) FROM schema_migrations
+                 WHERE name IN (?1, ?2)",
+                params![MIGRATION_001, MIGRATION_002],
                 |row| row.get(0),
             )
             .expect("query migration count");
-        assert_eq!(migration_count, 1);
+        assert_eq!(migration_count, 2);
         assert!(db_path.exists());
     }
 
@@ -253,7 +394,7 @@ mod tests {
             .connection
             .query_row("SELECT COUNT(*) FROM schema_migrations", [], |row| row.get(0))
             .expect("query migration count");
-        assert_eq!(migration_count, 1);
+        assert_eq!(migration_count, 2);
     }
 
     #[test]
@@ -330,5 +471,94 @@ mod tests {
             .expect_err("empty public key is invalid");
 
         assert!(matches!(error, StorageError::EmptyPublicKey));
+    }
+
+    #[test]
+    fn insert_and_fetch_message_ack() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = Storage::open(dir.path().join("dc.sqlite3")).expect("open storage");
+        let message_uuid = [0x11; 16];
+        let message_hash = [0x22; 32];
+        let acknowledger = [0x33; 32];
+
+        let record = storage
+            .upsert_message_ack(MessageAckUpsert {
+                message_uuid,
+                message_hash,
+                acknowledger,
+                signature: vec![4, 5, 6],
+            })
+            .expect("insert message ack");
+        let fetched = storage
+            .get_message_ack(message_uuid)
+            .expect("fetch message ack")
+            .expect("stored ack");
+
+        assert_eq!(record, fetched);
+        assert_eq!(fetched.message_uuid, message_uuid);
+        assert_eq!(fetched.message_hash, message_hash);
+        assert_eq!(fetched.acknowledger, acknowledger);
+        assert_eq!(fetched.signature, vec![4, 5, 6]);
+    }
+
+    #[test]
+    fn message_ack_migration_is_idempotent_on_existing_peer_key_database() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("dc.sqlite3");
+
+        {
+            let connection = Connection::open(&db_path).expect("open raw db");
+            connection
+                .execute_batch(
+                    "CREATE TABLE schema_migrations (
+                        name TEXT PRIMARY KEY,
+                        applied_at INTEGER NOT NULL
+                    );
+                    CREATE TABLE peer_keys (
+                        fingerprint BLOB PRIMARY KEY CHECK(length(fingerprint) = 32),
+                        nick TEXT,
+                        public_key BLOB NOT NULL CHECK(length(public_key) > 0),
+                        first_seen INTEGER NOT NULL,
+                        last_seen INTEGER NOT NULL,
+                        updated_at INTEGER NOT NULL
+                    );
+                    INSERT INTO schema_migrations (name, applied_at)
+                    VALUES ('001_peer_keys', 100);",
+                )
+                .expect("seed existing v0.2 db");
+        }
+
+        let storage = Storage::open(&db_path).expect("open migrated storage");
+        let migration_count: i64 = storage
+            .connection
+            .query_row("SELECT COUNT(*) FROM schema_migrations", [], |row| row.get(0))
+            .expect("query migration count");
+
+        assert_eq!(migration_count, 2);
+        storage
+            .upsert_message_ack(MessageAckUpsert {
+                message_uuid: [0x44; 16],
+                message_hash: [0x55; 32],
+                acknowledger: [0x66; 32],
+                signature: vec![7, 8, 9],
+            })
+            .expect("insert ack after migration");
+    }
+
+    #[test]
+    fn empty_message_ack_signature_is_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = Storage::open(dir.path().join("dc.sqlite3")).expect("open storage");
+
+        let error = storage
+            .upsert_message_ack(MessageAckUpsert {
+                message_uuid: [0x77; 16],
+                message_hash: [0x88; 32],
+                acknowledger: [0x99; 32],
+                signature: Vec::new(),
+            })
+            .expect_err("empty ack signature is invalid");
+
+        assert!(matches!(error, StorageError::EmptyAckSignature));
     }
 }


### PR DESCRIPTION
## Summary
- send signed type-5 ACKs after accepting valid type-4 chat messages
- validate received ACKs against the sent message UUID/hash and persist delivery state in SQLite
- add idempotent message ACK migrations plus loopback ACK persistence coverage

Closes #22

## Verification
- RUST_MIN_STACK=16777216 cargo test
- cargo fmt -- --check (unavailable: cargo-fmt is not installed)
- rustfmt --version (unavailable: rustfmt is not installed)
- cargo clippy --all-targets --all-features -- -D warnings (unavailable: clippy is not installed)