### PR TITLE
feat: add message ACK handling and persistence

### DIFF
--- a/src/message_transport.rs
+++ b/src/message_transport.rs
@@ -1,7 +1,8 @@
 use crate::{
-    codec::{self, ChatMessage, Message},
+    codec::{self, ChatMessage, Message, MessageAck},
     crypto,
     discovery::Fingerprint,
+    storage::{MessageAckRecord, MessageAckUpsert, Storage, StorageError},
 };
 use pgp::composed::{SignedPublicKey, SignedSecretKey};
 use rand::RngCore;
@@ -59,6 +60,22 @@ pub struct ReceivedChatMessage {
     pub message_hash: [u8; 32],
 }
 
+/// Verified type-5 acknowledgement for a previously sent type-4 message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReceivedMessageAck {
+    pub message_uuid: [u8; 16],
+    pub message_hash: [u8; 32],
+    pub acknowledger: Fingerprint,
+    pub signature: Vec<u8>,
+}
+
+/// Sent chat message plus the persisted ACK received from the peer.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AcknowledgedChatMessage {
+    pub message: ChatMessage,
+    pub ack: MessageAckRecord,
+}
+
 /// Running TCP receiver for encrypted signed type-4 messages.
 pub struct ChatMessageService {
     local_addr: SocketAddr,
@@ -95,8 +112,12 @@ pub enum ChatTransportError {
     Codec(#[from] codec::CodecError),
     #[error("expected chat message, received {received}")]
     UnexpectedMessage { received: &'static str },
+    #[error("expected message ack, received {received}")]
+    UnexpectedAck { received: &'static str },
     #[error("chat message version {version} is unsupported")]
     UnsupportedVersion { version: u8 },
+    #[error("message ack version {version} is unsupported")]
+    UnsupportedAckVersion { version: u8 },
     #[error("chat message conversation type {conv_type} is unsupported")]
     UnsupportedConversationType { conv_type: u8 },
     #[error("chat message id is not a UUID v4")]
@@ -109,16 +130,26 @@ pub enum ChatTransportError {
     SourceMismatch,
     #[error("chat message destination fingerprint did not match local identity")]
     DestinationMismatch,
+    #[error("message ack uuid did not match the sent message")]
+    AckMessageUuidMismatch,
+    #[error("message ack hash did not match the sent message")]
+    AckMessageHashMismatch,
+    #[error("message ack acknowledger fingerprint did not match expected peer")]
+    AckAcknowledgerMismatch,
     #[error("chat message timestamp is outside the accepted window")]
     TimestampOutOfWindow,
     #[error("chat headers are too large: {len} bytes, max 65535")]
     HeadersTooLarge { len: usize },
     #[error("chat message signature verification failed: {0}")]
     Signature(#[source] crypto::CryptoError),
+    #[error("message ack signature verification failed: {0}")]
+    AckSignature(#[source] crypto::CryptoError),
     #[error("chat payload encryption failed: {0}")]
     Encrypt(#[source] crypto::CryptoError),
     #[error("chat payload decryption failed: {0}")]
     Decrypt(#[source] crypto::CryptoError),
+    #[error("failed to persist message ack: {0}")]
+    Storage(#[from] StorageError),
     #[error("system clock is before the Unix epoch")]
     InvalidSystemTime,
 }
@@ -190,6 +221,43 @@ pub async fn send_chat_message(
     Ok(message)
 }
 
+/// Send one type-4 chat message, wait for its type-5 ACK, verify it, and store
+/// the delivery state in SQLite.
+pub async fn send_chat_message_and_record_ack(
+    peer_addr: SocketAddr,
+    local: &LocalChatIdentity,
+    peer: &PeerChatIdentity,
+    outgoing: OutgoingChatMessage,
+    storage: &Storage,
+) -> Result<AcknowledgedChatMessage, ChatTransportError> {
+    let message = build_chat_message(local, peer, outgoing)?;
+    let mut stream = TcpStream::connect(peer_addr)
+        .await
+        .map_err(|source| ChatTransportError::Connect {
+            addr: peer_addr,
+            source,
+        })?;
+
+    write_message(&mut stream, Message::ChatMessage(message.clone())).await?;
+
+    let response = read_message(&mut stream).await?;
+    let Message::MessageAck(ack) = response else {
+        return Err(ChatTransportError::UnexpectedAck {
+            received: message_name(&response),
+        });
+    };
+    let received_ack = accept_message_ack(ack, &message, peer)?;
+    let ack = storage.upsert_message_ack(MessageAckUpsert {
+        message_uuid: received_ack.message_uuid,
+        message_hash: received_ack.message_hash,
+        acknowledger: received_ack.acknowledger,
+        signature: received_ack.signature,
+        acknowledged_at: unix_timestamp()?,
+    })?;
+
+    Ok(AcknowledgedChatMessage { message, ack })
+}
+
 /// Verify, decrypt, and hash a received type-4 chat message.
 pub fn accept_chat_message(
     message: ChatMessage,
@@ -217,6 +285,26 @@ pub fn accept_chat_message(
         headers: message.headers,
         plaintext,
         message_hash,
+    })
+}
+
+/// Verify a received type-5 ACK against the original sent chat message.
+pub fn accept_message_ack(
+    ack: MessageAck,
+    sent: &ChatMessage,
+    peer: &PeerChatIdentity,
+) -> Result<ReceivedMessageAck, ChatTransportError> {
+    validate_message_ack(&ack, sent, peer)?;
+
+    let signature_digest = message_ack_signature_digest(&ack);
+    crypto::verify(&peer.public_key, &signature_digest, &ack.signature)
+        .map_err(ChatTransportError::AckSignature)?;
+
+    Ok(ReceivedMessageAck {
+        message_uuid: ack.uuid,
+        message_hash: ack.message_hash,
+        acknowledger: ack.acknowledger,
+        signature: ack.signature,
     })
 }
 
@@ -300,7 +388,11 @@ async fn handle_connection(
         });
     };
 
-    accept_chat_message(message, local, peer, expected_previous_hash)
+    let received = accept_chat_message(message, local, peer, expected_previous_hash)?;
+    let ack = build_message_ack(local, &received)?;
+    let _ = write_message(&mut stream, Message::MessageAck(ack)).await;
+
+    Ok(received)
 }
 
 fn validate_chat_message(
@@ -340,6 +432,47 @@ fn validate_chat_message(
     Ok(())
 }
 
+fn build_message_ack(
+    local: &LocalChatIdentity,
+    received: &ReceivedChatMessage,
+) -> Result<MessageAck, ChatTransportError> {
+    let mut ack = MessageAck {
+        version: WIRE_CHAT_VERSION,
+        uuid: received.uuid,
+        message_hash: received.message_hash,
+        acknowledger: local.fingerprint,
+        signature: Vec::new(),
+    };
+    let signature_digest = message_ack_signature_digest(&ack);
+    ack.signature = crypto::sign(&local.secret_key, &signature_digest)
+        .map_err(ChatTransportError::AckSignature)?;
+
+    Ok(ack)
+}
+
+fn validate_message_ack(
+    ack: &MessageAck,
+    sent: &ChatMessage,
+    peer: &PeerChatIdentity,
+) -> Result<(), ChatTransportError> {
+    if ack.version != WIRE_CHAT_VERSION {
+        return Err(ChatTransportError::UnsupportedAckVersion {
+            version: ack.version,
+        });
+    }
+    if ack.uuid != sent.uuid {
+        return Err(ChatTransportError::AckMessageUuidMismatch);
+    }
+    let sent_hash: [u8; 32] = Sha256::digest(Vec::<u8>::from(sent.clone())).into();
+    if ack.message_hash != sent_hash {
+        return Err(ChatTransportError::AckMessageHashMismatch);
+    }
+    if ack.acknowledger != peer.fingerprint {
+        return Err(ChatTransportError::AckAcknowledgerMismatch);
+    }
+    Ok(())
+}
+
 fn chat_message_signed_bytes(message: &ChatMessage) -> Vec<u8> {
     let mut out = Vec::new();
     out.push(message.version);
@@ -359,6 +492,19 @@ fn chat_message_signed_bytes(message: &ChatMessage) -> Vec<u8> {
 
 fn chat_message_signature_digest(message: &ChatMessage) -> [u8; 32] {
     Sha256::digest(chat_message_signed_bytes(message)).into()
+}
+
+fn message_ack_signed_bytes(ack: &MessageAck) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push(ack.version);
+    out.extend_from_slice(&ack.uuid);
+    out.extend_from_slice(&ack.message_hash);
+    out.extend_from_slice(&ack.acknowledger);
+    out
+}
+
+fn message_ack_signature_digest(ack: &MessageAck) -> [u8; 32] {
+    Sha256::digest(message_ack_signed_bytes(ack)).into()
 }
 
 async fn read_message(stream: &mut TcpStream) -> Result<Message, ChatTransportError> {
@@ -465,6 +611,7 @@ fn message_name(message: &Message) -> &'static str {
 mod tests {
     use super::*;
     use crate::crypto::{fingerprint, public_key_to_bytes, KeyPair};
+    use crate::storage::Storage;
     use std::net::{IpAddr, Ipv4Addr};
     use tokio::time::{timeout, Duration};
 
@@ -550,6 +697,56 @@ mod tests {
         assert_ne!(sent.data, b"hello bob");
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn loopback_ack_records_delivery_state() {
+        let (alice_local, bob_peer, bob_local, alice_peer) = identities();
+        let previous_hash = [0x62; 32];
+        let mut receiver = ChatMessageService::start(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            bob_local,
+            alice_peer,
+            previous_hash,
+        )
+        .await
+        .expect("start chat receiver");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = Storage::open(dir.path().join("sender.sqlite3")).expect("open storage");
+
+        let acknowledged = timeout(
+            Duration::from_secs(10),
+            send_chat_message_and_record_ack(
+                receiver.local_addr(),
+                &alice_local,
+                &bob_peer,
+                OutgoingChatMessage {
+                    conversation_uuid: uuid_v4(0x71),
+                    previous_hash,
+                    headers: b"Content-Type: text/plain".to_vec(),
+                    plaintext: b"ack me".to_vec(),
+                },
+                &storage,
+            ),
+        )
+        .await
+        .expect("send and ack should finish")
+        .expect("send and record ack");
+        let received = timeout(Duration::from_secs(10), receiver.recv())
+            .await
+            .expect("receive should finish")
+            .expect("accepted message");
+        let stored = storage
+            .get_message_ack(acknowledged.message.uuid, bob_peer.fingerprint)
+            .expect("fetch message ack")
+            .expect("stored ack");
+
+        assert_eq!(received.uuid, acknowledged.message.uuid);
+        assert_eq!(acknowledged.ack, stored);
+        assert_eq!(stored.message_uuid, acknowledged.message.uuid);
+        assert_eq!(stored.message_hash, received.message_hash);
+        assert_eq!(stored.acknowledger, bob_peer.fingerprint);
+        assert!(!stored.signature.is_empty());
+    }
+
     #[test]
     fn invalid_signature_is_rejected_before_decryption() {
         let (alice_local, bob_peer, bob_local, alice_peer) = identities();
@@ -592,5 +789,40 @@ mod tests {
             .expect_err("wrong previous hash should be rejected");
 
         assert!(matches!(error, ChatTransportError::PreviousHashMismatch));
+    }
+
+    #[test]
+    fn ack_signature_must_verify_with_acknowledger_key() {
+        let (alice_local, bob_peer, bob_local, _alice_peer) = identities();
+        let message = build_chat_message(
+            &alice_local,
+            &bob_peer,
+            OutgoingChatMessage {
+                conversation_uuid: uuid_v4(0x73),
+                previous_hash: [0x81; 32],
+                headers: Vec::new(),
+                plaintext: b"delivery proof".to_vec(),
+            },
+        )
+        .expect("build message");
+        let message_hash = Sha256::digest(Vec::<u8>::from(message.clone())).into();
+        let received = ReceivedChatMessage {
+            uuid: message.uuid,
+            conversation_uuid: message.conv_uuid,
+            previous_hash: message.prev_hash,
+            timestamp: message.timestamp,
+            source: alice_local.fingerprint,
+            destination: bob_peer.fingerprint,
+            headers: message.headers.clone(),
+            plaintext: b"delivery proof".to_vec(),
+            message_hash,
+        };
+        let mut ack = build_message_ack(&bob_local, &received).expect("build ack");
+        ack.signature[0] ^= 0xff;
+
+        let error = accept_message_ack(ack, &message, &bob_peer)
+            .expect_err("tampered ack signature should be rejected");
+
+        assert!(matches!(error, ChatTransportError::AckSignature(_)));
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,6 +8,7 @@ use std::{
 use thiserror::Error;
 
 const MIGRATION_001: &str = "001_peer_keys";
+const MIGRATION_002: &str = "002_message_acks";
 
 /// SQLite-backed local storage for DecentraChat peer data.
 pub struct Storage {
@@ -34,6 +35,27 @@ pub struct PeerKeyUpsert {
     pub last_seen: i64,
 }
 
+/// Persisted delivery acknowledgement for an outbound message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageAckRecord {
+    pub message_uuid: [u8; 16],
+    pub message_hash: [u8; 32],
+    pub acknowledger: Fingerprint,
+    pub signature: Vec<u8>,
+    pub acknowledged_at: i64,
+    pub updated_at: i64,
+}
+
+/// Data accepted by the message-ack repository upsert operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageAckUpsert {
+    pub message_uuid: [u8; 16],
+    pub message_hash: [u8; 32],
+    pub acknowledger: Fingerprint,
+    pub signature: Vec<u8>,
+    pub acknowledged_at: i64,
+}
+
 /// Errors returned by SQLite storage initialization and repository operations.
 #[derive(Debug, Error)]
 pub enum StorageError {
@@ -57,6 +79,12 @@ pub enum StorageError {
     EmptyPublicKey,
     #[error("stored peer fingerprint must be 32 bytes, got {len}")]
     InvalidFingerprintLength { len: usize },
+    #[error("stored message UUID must be 16 bytes, got {len}")]
+    InvalidMessageUuidLength { len: usize },
+    #[error("stored message hash must be 32 bytes, got {len}")]
+    InvalidMessageHashLength { len: usize },
+    #[error("message ACK signature must not be empty")]
+    EmptyAckSignature,
     #[error("system clock is before the Unix epoch")]
     InvalidSystemTime,
 }
@@ -136,6 +164,61 @@ impl Storage {
             .map(validate_record)
             .transpose()
     }
+
+    /// Insert or update an acknowledgement for an outbound message.
+    pub fn upsert_message_ack(
+        &self,
+        upsert: MessageAckUpsert,
+    ) -> Result<MessageAckRecord, StorageError> {
+        if upsert.signature.is_empty() {
+            return Err(StorageError::EmptyAckSignature);
+        }
+
+        let now = unix_timestamp()?;
+        self.connection
+            .execute(
+                "INSERT INTO message_acks (
+                    message_uuid, message_hash, acknowledger, signature, acknowledged_at, updated_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                ON CONFLICT(message_uuid, acknowledger) DO UPDATE SET
+                    message_hash = excluded.message_hash,
+                    signature = excluded.signature,
+                    acknowledged_at = excluded.acknowledged_at,
+                    updated_at = excluded.updated_at",
+                params![
+                    &upsert.message_uuid[..],
+                    &upsert.message_hash[..],
+                    &upsert.acknowledger[..],
+                    upsert.signature,
+                    upsert.acknowledged_at,
+                    now,
+                ],
+            )
+            .map_err(StorageError::Repository)?;
+
+        self.get_message_ack(upsert.message_uuid, upsert.acknowledger)?
+            .ok_or_else(|| StorageError::Repository(rusqlite::Error::QueryReturnedNoRows))
+    }
+
+    /// Fetch a persisted acknowledgement by message id and acknowledging peer.
+    pub fn get_message_ack(
+        &self,
+        message_uuid: [u8; 16],
+        acknowledger: Fingerprint,
+    ) -> Result<Option<MessageAckRecord>, StorageError> {
+        self.connection
+            .query_row(
+                "SELECT message_uuid, message_hash, acknowledger, signature, acknowledged_at, updated_at
+                 FROM message_acks
+                 WHERE message_uuid = ?1 AND acknowledger = ?2",
+                params![&message_uuid[..], &acknowledger[..]],
+                row_to_message_ack,
+            )
+            .optional()
+            .map_err(StorageError::Repository)?
+            .map(validate_message_ack_record)
+            .transpose()
+    }
 }
 
 fn apply_migrations(connection: &mut Connection) -> Result<(), StorageError> {
@@ -158,16 +241,32 @@ fn apply_migrations(connection: &mut Connection) -> Result<(), StorageError> {
             );
 
             CREATE INDEX IF NOT EXISTS idx_peer_keys_last_seen
-                ON peer_keys(last_seen);",
+                ON peer_keys(last_seen);
+
+            CREATE TABLE IF NOT EXISTS message_acks (
+                message_uuid BLOB NOT NULL CHECK(length(message_uuid) = 16),
+                message_hash BLOB NOT NULL CHECK(length(message_hash) = 32),
+                acknowledger BLOB NOT NULL CHECK(length(acknowledger) = 32),
+                signature BLOB NOT NULL CHECK(length(signature) > 0),
+                acknowledged_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY(message_uuid, acknowledger)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_message_acks_acknowledged_at
+                ON message_acks(acknowledged_at);",
         )
         .map_err(StorageError::Migration)?;
 
-    transaction
-        .execute(
-            "INSERT OR IGNORE INTO schema_migrations (name, applied_at) VALUES (?1, ?2)",
-            params![MIGRATION_001, unix_timestamp()?],
-        )
-        .map_err(StorageError::Migration)?;
+    let now = unix_timestamp()?;
+    for migration in [MIGRATION_001, MIGRATION_002] {
+        transaction
+            .execute(
+                "INSERT OR IGNORE INTO schema_migrations (name, applied_at) VALUES (?1, ?2)",
+                params![migration, now],
+            )
+            .map_err(StorageError::Migration)?;
+    }
 
     transaction.commit().map_err(StorageError::Migration)
 }
@@ -196,10 +295,60 @@ fn validate_record(record: PeerKeyRecord) -> Result<PeerKeyRecord, StorageError>
     Ok(record)
 }
 
+fn row_to_message_ack(row: &rusqlite::Row<'_>) -> rusqlite::Result<MessageAckRecord> {
+    Ok(MessageAckRecord {
+        message_uuid: vec_to_message_uuid(row.get(0)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                16,
+                rusqlite::types::Type::Blob,
+                Box::new(error),
+            )
+        })?,
+        message_hash: vec_to_message_hash(row.get(1)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                32,
+                rusqlite::types::Type::Blob,
+                Box::new(error),
+            )
+        })?,
+        acknowledger: vec_to_fingerprint(row.get(2)?).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                32,
+                rusqlite::types::Type::Blob,
+                Box::new(error),
+            )
+        })?,
+        signature: row.get(3)?,
+        acknowledged_at: row.get(4)?,
+        updated_at: row.get(5)?,
+    })
+}
+
+fn validate_message_ack_record(
+    record: MessageAckRecord,
+) -> Result<MessageAckRecord, StorageError> {
+    if record.signature.is_empty() {
+        return Err(StorageError::EmptyAckSignature);
+    }
+    Ok(record)
+}
+
 fn vec_to_fingerprint(bytes: Vec<u8>) -> Result<Fingerprint, StorageError> {
     bytes
         .try_into()
         .map_err(|bytes: Vec<u8>| StorageError::InvalidFingerprintLength { len: bytes.len() })
+}
+
+fn vec_to_message_uuid(bytes: Vec<u8>) -> Result<[u8; 16], StorageError> {
+    bytes
+        .try_into()
+        .map_err(|bytes: Vec<u8>| StorageError::InvalidMessageUuidLength { len: bytes.len() })
+}
+
+fn vec_to_message_hash(bytes: Vec<u8>) -> Result<[u8; 32], StorageError> {
+    bytes
+        .try_into()
+        .map_err(|bytes: Vec<u8>| StorageError::InvalidMessageHashLength { len: bytes.len() })
 }
 
 fn unix_timestamp() -> Result<i64, StorageError> {
@@ -253,7 +402,7 @@ mod tests {
             .connection
             .query_row("SELECT COUNT(*) FROM schema_migrations", [], |row| row.get(0))
             .expect("query migration count");
-        assert_eq!(migration_count, 1);
+        assert_eq!(migration_count, 2);
     }
 
     #[test]
@@ -330,5 +479,62 @@ mod tests {
             .expect_err("empty public key is invalid");
 
         assert!(matches!(error, StorageError::EmptyPublicKey));
+    }
+
+    #[test]
+    fn insert_update_and_fetch_message_ack() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = Storage::open(dir.path().join("dc.sqlite3")).expect("open storage");
+        let message_uuid = [0x11; 16];
+        let acknowledger = [0x22; 32];
+
+        let initial = storage
+            .upsert_message_ack(MessageAckUpsert {
+                message_uuid,
+                message_hash: [0x33; 32],
+                acknowledger,
+                signature: b"signature-one".to_vec(),
+                acknowledged_at: 100,
+            })
+            .expect("insert message ack");
+        let updated = storage
+            .upsert_message_ack(MessageAckUpsert {
+                message_uuid,
+                message_hash: [0x44; 32],
+                acknowledger,
+                signature: b"signature-two".to_vec(),
+                acknowledged_at: 200,
+            })
+            .expect("update message ack");
+        let fetched = storage
+            .get_message_ack(message_uuid, acknowledger)
+            .expect("fetch message ack")
+            .expect("stored ack");
+
+        assert_eq!(updated, fetched);
+        assert_eq!(fetched.message_uuid, message_uuid);
+        assert_eq!(fetched.message_hash, [0x44; 32]);
+        assert_eq!(fetched.acknowledger, acknowledger);
+        assert_eq!(fetched.signature, b"signature-two");
+        assert_eq!(fetched.acknowledged_at, 200);
+        assert!(updated.updated_at >= initial.updated_at);
+    }
+
+    #[test]
+    fn empty_ack_signature_is_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = Storage::open(dir.path().join("dc.sqlite3")).expect("open storage");
+
+        let error = storage
+            .upsert_message_ack(MessageAckUpsert {
+                message_uuid: [0x11; 16],
+                message_hash: [0x22; 32],
+                acknowledger: [0x33; 32],
+                signature: Vec::new(),
+                acknowledged_at: 100,
+            })
+            .expect_err("empty signature is invalid");
+
+        assert!(matches!(error, StorageError::EmptyAckSignature));
     }
 }


### PR DESCRIPTION
## Summary
- send signed type-5 ACKs on valid type-4 chat message receipt
- add sender ACK verification and SQLite delivery-state persistence
- add idempotent message_acks migration plus storage and loopback tests

Closes #22

## Verification
- RUST_MIN_STACK=16777216 cargo test
- cargo fmt unavailable: no cargo-fmt/rustfmt command in toolchain
- cargo clippy --all-targets --all-features -- -D warnings unavailable: no cargo-clippy command in toolchain