### PR TITLE
feat: add bounded discovery CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,19 @@ Show the current command surface:
 cargo run -- --help
 ```
 
-Peer discovery and message sending are planned for later v1.0 work.
+Run a bounded local peer discovery session and print the visible peers:
+
+```sh
+cargo run -- discover --duration-ms 5000 --announce-interval-ms 1000 --nick local --fingerprint 0000000000000000000000000000000000000000000000000000000000000000
+```
+
+When testing multicast loopback on one machine, bind discovery to loopback explicitly:
+
+```sh
+cargo run -- --config ./config.toml discover --multicast-interface 127.0.0.1 --listen-port 51001 --duration-ms 3000
+```
+
+Encrypted message sending is planned for later v1.0 work.
 
 ## Protocol and architecture
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,12 +1,18 @@
 use crate::{
     config::{default_config_path, Config, ConfigError},
+    discovery::{
+        Discovery, DiscoveryError, DiscoverySettings, Fingerprint, LocalNode, PeerEntry,
+    },
     storage::{Storage, StorageError},
 };
 use clap::{CommandFactory, Parser, Subcommand};
+use std::net::{IpAddr, Ipv4Addr};
 use std::{
+    collections::HashMap,
     ffi::OsString,
     io::{self, Write},
     path::PathBuf,
+    time::{Duration, Instant},
 };
 use thiserror::Error;
 
@@ -15,7 +21,7 @@ use thiserror::Error;
     name = "decentra-chat",
     version,
     about = "Local-first peer-to-peer chat client",
-    long_about = "DecentraChat is a local-first peer-to-peer chat client. The current command surface bootstraps configuration and storage diagnostics without starting network services."
+    long_about = "DecentraChat is a local-first peer-to-peer chat client. The current command surface bootstraps configuration, storage diagnostics, and bounded LAN peer discovery."
 )]
 pub struct Cli {
     /// Path to config.toml. Defaults to DC_CONFIG or the platform config directory.
@@ -26,10 +32,38 @@ pub struct Cli {
     command: Option<CliCommand>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Subcommand)]
+#[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
 pub enum CliCommand {
     /// Load config, apply storage migrations, and print non-secret node settings.
     Status,
+    /// Run bounded UDP multicast discovery and print the visible peer list.
+    Discover(DiscoverArgs),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
+pub struct DiscoverArgs {
+    /// Nickname advertised in discovery announcements.
+    #[arg(long, default_value = "local")]
+    nick: String,
+    /// Hex-encoded 32-byte public-key fingerprint to advertise.
+    #[arg(
+        long,
+        value_name = "HEX",
+        default_value = "0000000000000000000000000000000000000000000000000000000000000000"
+    )]
+    fingerprint: String,
+    /// TCP port advertised to peers for follow-up direct connections.
+    #[arg(long, default_value_t = 0)]
+    listen_port: u16,
+    /// Local IPv4 interface used for multicast joins and sends.
+    #[arg(long, value_name = "IPv4")]
+    multicast_interface: Option<Ipv4Addr>,
+    /// Bounded discovery run length in milliseconds.
+    #[arg(long, default_value_t = 5_000)]
+    duration_ms: u64,
+    /// Announcement interval in milliseconds.
+    #[arg(long, default_value_t = 1_000)]
+    announce_interval_ms: u64,
 }
 
 #[derive(Debug, Error)]
@@ -46,6 +80,21 @@ pub enum CliError {
         #[source]
         source: StorageError,
     },
+    #[error("config field `{field}` must be an IPv4 address for discovery, got {value}")]
+    DiscoveryRequiresIpv4 {
+        field: &'static str,
+        value: IpAddr,
+    },
+    #[error("invalid discovery fingerprint: {0}")]
+    InvalidFingerprint(String),
+    #[error("discovery duration must be greater than zero")]
+    InvalidDiscoveryDuration,
+    #[error("discovery announcement interval must be greater than zero")]
+    InvalidAnnounceInterval,
+    #[error("failed to start discovery session: {0}")]
+    StartDiscovery(#[from] DiscoveryError),
+    #[error("failed to create async runtime for discovery: {0}")]
+    CreateRuntime(#[source] io::Error),
     #[error("failed to write CLI output: {0}")]
     WriteOutput(#[from] io::Error),
 }
@@ -65,7 +114,7 @@ impl Cli {
     }
 
     fn command(&self) -> CliCommand {
-        self.command.unwrap_or(CliCommand::Status)
+        self.command.clone().unwrap_or(CliCommand::Status)
     }
 
     fn config_path(&self) -> PathBuf {
@@ -88,6 +137,13 @@ pub fn run<W: Write>(cli: Cli, mut writer: W) -> Result<(), CliError> {
         CliCommand::Status => {
             let report = load_status(cli.config_path())?;
             write_status(&mut writer, &report)?;
+        }
+        CliCommand::Discover(args) => {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(CliError::CreateRuntime)?;
+            runtime.block_on(run_discovery(cli.config_path(), args, &mut writer))?;
         }
     }
     Ok(())
@@ -124,11 +180,161 @@ pub fn write_status<W: Write>(writer: &mut W, report: &StatusReport) -> Result<(
     Ok(())
 }
 
+pub async fn run_discovery<W: Write>(
+    config_path: PathBuf,
+    args: DiscoverArgs,
+    writer: &mut W,
+) -> Result<(), CliError> {
+    if args.duration_ms == 0 {
+        return Err(CliError::InvalidDiscoveryDuration);
+    }
+    if args.announce_interval_ms == 0 {
+        return Err(CliError::InvalidAnnounceInterval);
+    }
+
+    let config = Config::load_from_path(&config_path).map_err(|source| CliError::LoadConfig {
+        path: config_path.clone(),
+        source,
+    })?;
+    Storage::open(&config.storage_path).map_err(|source| CliError::InitializeStorage {
+        path: config.storage_path.clone(),
+        source,
+    })?;
+
+    let multicast_group = require_ipv4("multicast_group", config.multicast_group)?;
+    let listen_addr = require_ipv4("listen_addr", config.listen_addr)?;
+    let settings = DiscoverySettings::new(multicast_group, config.discovery_port, listen_addr)
+        .with_multicast_interface(args.multicast_interface.unwrap_or(Ipv4Addr::UNSPECIFIED))
+        .with_announce_interval(Duration::from_millis(args.announce_interval_ms));
+    let local_node = LocalNode {
+        nick: args.nick.as_bytes().to_vec(),
+        listen_port: args.listen_port,
+        fingerprint: parse_fingerprint(&args.fingerprint)?,
+        public_key_blob: None,
+    };
+
+    let discovery = Discovery::start(settings.clone(), local_node).await?;
+    writeln!(
+        writer,
+        "discovery: running for {} ms on {}:{}",
+        args.duration_ms, settings.multicast_group, settings.discovery_port
+    )?;
+
+    let started = Instant::now();
+    let deadline = Duration::from_millis(args.duration_ms);
+    let progress_interval = Duration::from_secs(1);
+    loop {
+        let elapsed = started.elapsed();
+        if elapsed >= deadline {
+            break;
+        }
+
+        let sleep_for = (deadline - elapsed).min(progress_interval);
+        tokio::time::sleep(sleep_for).await;
+        let elapsed_ms = started.elapsed().min(deadline).as_millis();
+        writeln!(writer, "discovery: elapsed_ms={elapsed_ms}")?;
+    }
+
+    write_peer_list(writer, &discovery.registry_snapshot(), Instant::now())?;
+    Ok(())
+}
+
+fn require_ipv4(field: &'static str, value: IpAddr) -> Result<Ipv4Addr, CliError> {
+    match value {
+        IpAddr::V4(value) => Ok(value),
+        IpAddr::V6(_) => Err(CliError::DiscoveryRequiresIpv4 { field, value }),
+    }
+}
+
+fn parse_fingerprint(input: &str) -> Result<Fingerprint, CliError> {
+    if input.len() != 64 {
+        return Err(CliError::InvalidFingerprint(
+            "expected exactly 64 hex characters".to_owned(),
+        ));
+    }
+
+    let mut fingerprint = [0_u8; 32];
+    for (index, chunk) in input.as_bytes().chunks_exact(2).enumerate() {
+        let high = hex_value(chunk[0]).ok_or_else(|| {
+            CliError::InvalidFingerprint(format!(
+                "invalid hex character at byte {}",
+                index * 2
+            ))
+        })?;
+        let low = hex_value(chunk[1]).ok_or_else(|| {
+            CliError::InvalidFingerprint(format!(
+                "invalid hex character at byte {}",
+                index * 2 + 1
+            ))
+        })?;
+        fingerprint[index] = (high << 4) | low;
+    }
+    Ok(fingerprint)
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn write_peer_list<W: Write>(
+    writer: &mut W,
+    peers: &HashMap<Fingerprint, PeerEntry>,
+    now: Instant,
+) -> Result<(), io::Error> {
+    writeln!(writer, "peers: {}", peers.len())?;
+    writeln!(writer, "nick\tfingerprint\taddress\tlast_seen_ms_ago")?;
+
+    let mut peers = peers.values().collect::<Vec<_>>();
+    peers.sort_by(|left, right| {
+        left.nick
+            .cmp(&right.nick)
+            .then_with(|| left.listen_addr.cmp(&right.listen_addr))
+            .then_with(|| left.fingerprint.cmp(&right.fingerprint))
+    });
+
+    for peer in peers {
+        writeln!(
+            writer,
+            "{}\t{}\t{}\t{}",
+            peer.nick,
+            fingerprint_hex(&peer.fingerprint),
+            peer.listen_addr,
+            now.saturating_duration_since(peer.last_seen).as_millis()
+        )?;
+    }
+    Ok(())
+}
+
+fn fingerprint_hex(fingerprint: &Fingerprint) -> String {
+    let mut output = String::with_capacity(64);
+    for byte in fingerprint {
+        output.push(nibble_hex(byte >> 4));
+        output.push(nibble_hex(byte & 0x0f));
+    }
+    output
+}
+
+fn nibble_hex(value: u8) -> char {
+    match value {
+        0..=9 => (b'0' + value) as char,
+        10..=15 => (b'a' + value - 10) as char,
+        _ => unreachable!("nibble value is always <= 15"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use clap::Parser;
     use std::fs;
+    use std::sync::atomic::{AtomicU16, Ordering};
+
+    static NEXT_DISCOVERY_PORT: AtomicU16 = AtomicU16::new(43091);
 
     #[test]
     fn parses_status_subcommand_with_config_path() {
@@ -156,6 +362,19 @@ mod tests {
         assert!(help.contains("Usage: decentra-chat [OPTIONS] [COMMAND]"));
         assert!(help.contains("--config <PATH>"));
         assert!(help.contains("status"));
+        assert!(help.contains("discover"));
+
+        let mut command = Cli::command_for_help();
+        let discover = command
+            .find_subcommand_mut("discover")
+            .expect("discover subcommand");
+        let mut discover_help = Vec::new();
+        discover
+            .write_long_help(&mut discover_help)
+            .expect("write discover help");
+        let discover_help = String::from_utf8(discover_help).expect("help is UTF-8");
+
+        assert!(discover_help.contains("--duration-ms <DURATION_MS>"));
     }
 
     #[test]
@@ -211,5 +430,102 @@ storage_path = "{}"
         assert!(error.contains(&config_path.display().to_string()));
         assert!(error.contains("multicast_group"));
         assert!(error.contains("valid IP address"));
+    }
+
+    #[test]
+    fn parses_discover_subcommand_with_bounded_options() {
+        let cli = Cli::parse_from([
+            "decentra-chat",
+            "--config",
+            "config.toml",
+            "discover",
+            "--nick",
+            "alice",
+            "--fingerprint",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "--listen-port",
+            "51001",
+            "--multicast-interface",
+            "127.0.0.1",
+            "--duration-ms",
+            "25",
+            "--announce-interval-ms",
+            "10",
+        ]);
+
+        assert_eq!(
+            cli.command(),
+            CliCommand::Discover(DiscoverArgs {
+                nick: "alice".to_owned(),
+                fingerprint: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    .to_owned(),
+                listen_port: 51001,
+                multicast_interface: Some(Ipv4Addr::LOCALHOST),
+                duration_ms: 25,
+                announce_interval_ms: 10,
+            })
+        );
+    }
+
+    #[test]
+    fn bounded_discover_prints_progress_and_peer_list() {
+        let port = NEXT_DISCOVERY_PORT.fetch_add(1, Ordering::Relaxed);
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage_path = dir.path().join("state").join("chat.sqlite3");
+        let config_path = dir.path().join("config.toml");
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+multicast_group = "239.255.40.91"
+discovery_port = {port}
+listen_addr = "127.0.0.1"
+storage_path = "{}"
+"#,
+                storage_path.display()
+            ),
+        )
+        .expect("write config");
+        let fingerprint = "1111111111111111111111111111111111111111111111111111111111111111";
+        let mut output = Vec::new();
+
+        run_from(
+            [
+                "decentra-chat",
+                "--config",
+                config_path.to_str().expect("utf-8 path"),
+                "discover",
+                "--nick",
+                "alice",
+                "--fingerprint",
+                fingerprint,
+                "--listen-port",
+                "51001",
+                "--multicast-interface",
+                "127.0.0.1",
+                "--duration-ms",
+                "150",
+                "--announce-interval-ms",
+                "25",
+            ],
+            &mut output,
+        )
+        .expect("bounded discovery succeeds");
+
+        let output = String::from_utf8(output).expect("discovery output is UTF-8");
+        assert!(output.contains("discovery: running for 150 ms"));
+        assert!(output.contains("discovery: elapsed_ms="));
+        assert!(output.contains("peers:"));
+        assert!(output.contains("nick\tfingerprint\taddress\tlast_seen_ms_ago"));
+        assert!(output.contains("alice"));
+        assert!(output.contains(fingerprint));
+        assert!(output.contains("127.0.0.1:51001"));
+    }
+
+    #[test]
+    fn invalid_discovery_fingerprint_is_actionable() {
+        let error = parse_fingerprint("not-hex").expect_err("fingerprint is invalid");
+
+        assert!(error.to_string().contains("64 hex characters"));
     }
 }


### PR DESCRIPTION
## Summary
- add a bounded `discover` subcommand that starts UDP multicast discovery from config
- print progress updates and a peer-list table with nick, fingerprint, address, and last-seen age
- document copy-pasteable discovery examples

Closes #39

## Verification
- `RUST_MIN_STACK=16777216 cargo test`
- `RUST_MIN_STACK=16777216 cargo run -- discover --duration-ms 100 --announce-interval-ms 25 --multicast-interface 127.0.0.1 --listen-port 51001`
- `git diff --check`

## Notes
- Plain `cargo test --no-run` hit the known rustc stack overflow while compiling `p521`; rerunning with `RUST_MIN_STACK=16777216` passed.
- `cargo fmt`/`rustfmt` and `cargo clippy` are unavailable in this toolchain.