### PR TITLE
feat: add contact book and fingerprint pinning

### DIFF
--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -1,9 +1,9 @@
 # CLI User Guide
 
 The DecentraChat CLI is the current user-facing client. It can inspect local
-configuration, initialize storage, run bounded LAN discovery, exchange public
-keys, send and receive one encrypted message, and read conversation history from
-SQLite.
+configuration, initialize storage, manage local contacts, run bounded LAN
+discovery, exchange public keys, send and receive one encrypted message, and
+read conversation history from SQLite.
 
 The commands below describe what is implemented in `src/cli.rs` today. There is
 no TUI or long-running chat daemon yet.
@@ -200,6 +200,51 @@ cargo run -- --config ./bob.toml key-request --peer 127.0.0.1:52002
 `send` and `receive` require the peer fingerprint to exist in local storage.
 When it is missing, the CLI exits with an error that points back to
 `key-request`.
+
+## Contact Book and Trust
+
+Contacts are local aliases pinned to peer fingerprints in the configured SQLite
+store. They do not replace raw fingerprint workflows yet; `key-request`, `send`,
+`receive`, `conversations`, and `history` still accept the same fingerprint
+arguments as before.
+
+Add or update an alias for a fingerprint:
+
+```sh
+cargo run -- --config ./alice.toml contact add \
+  --alias bob \
+  --fingerprint "$BOB_FINGERPRINT"
+```
+
+List contacts:
+
+```sh
+cargo run -- --config ./alice.toml contact list
+```
+
+Show one contact by alias or fingerprint:
+
+```sh
+cargo run -- --config ./alice.toml contact show bob
+cargo run -- --config ./alice.toml contact show "$BOB_FINGERPRINT"
+```
+
+Mark a contact as explicitly trusted/pinned after verifying the fingerprint:
+
+```sh
+cargo run -- --config ./alice.toml contact trust bob
+```
+
+Contact output is tab-separated:
+
+```text
+alias	fingerprint	public_key_present	trust_state	created_at	updated_at
+```
+
+Aliases are case-insensitive for lookup and uniqueness. The CLI rejects empty
+aliases, aliases with leading or trailing spaces, control characters, tabs, or
+newlines, and aliases longer than 64 bytes. Reusing an alias for a different
+fingerprint fails with an actionable conflict error.
 
 ## Sending and Receiving
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -339,7 +339,7 @@ so test on the target LAN when possible.
 
 - Commands are intentionally bounded and exit after one operation or a fixed
   duration.
-- There is no TUI, background daemon, contact book, or automatic retry loop yet.
+- There is no TUI, background daemon, or automatic retry loop yet.
 - Discovery is local-network multicast. It does not cross routers without
   network support.
 - Conversation history is local storage state. It does not fetch missing

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,10 @@ use crate::{
         self, ChatMessageService, ChatTransportError, LocalChatIdentity, OutgoingChatMessage,
         PeerChatIdentity,
     },
-    storage::{AcceptedChatMessageInsert, Storage, StorageError},
+    storage::{
+        AcceptedChatMessageInsert, ContactRecord, ContactTrustState, ContactUpsert, Storage,
+        StorageError,
+    },
 };
 use clap::{CommandFactory, Parser, Subcommand};
 use pgp::composed::SignedSecretKey;
@@ -65,6 +68,8 @@ pub enum CliCommand {
     Conversations,
     /// Show ordered message history for one conversation.
     History(HistoryArgs),
+    /// Manage local contact aliases and pinned trust state.
+    Contact(ContactArgs),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
@@ -179,6 +184,41 @@ pub struct HistoryArgs {
     conversation: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
+pub struct ContactArgs {
+    #[command(subcommand)]
+    command: ContactCommand,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
+pub enum ContactCommand {
+    /// Add or update a local alias for a peer fingerprint.
+    Add(ContactAddArgs),
+    /// List local contacts.
+    List,
+    /// Show one contact by fingerprint or alias.
+    Show(ContactLookupArgs),
+    /// Mark one contact as explicitly trusted/pinned.
+    Trust(ContactLookupArgs),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
+pub struct ContactAddArgs {
+    /// Stable local alias for this peer.
+    #[arg(long, value_name = "ALIAS")]
+    alias: String,
+    /// Hex-encoded 32-byte peer fingerprint.
+    #[arg(long, value_name = "HEX")]
+    fingerprint: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
+pub struct ContactLookupArgs {
+    /// Hex-encoded 32-byte fingerprint or stored alias.
+    #[arg(value_name = "FINGERPRINT_OR_ALIAS")]
+    query: String,
+}
+
 #[derive(Debug, Error)]
 pub enum CliError {
     #[error("failed to load config from {path}: {source}")]
@@ -200,6 +240,16 @@ pub enum CliError {
     },
     #[error("invalid discovery fingerprint: {0}")]
     InvalidFingerprint(String),
+    #[error("invalid contact alias `{alias}`: use 1-64 visible characters without tabs, newlines, or leading/trailing spaces")]
+    InvalidContactAlias { alias: String },
+    #[error(
+        "contact `{query}` is not in local storage; run `contact add --alias <ALIAS> --fingerprint <HEX>` first"
+    )]
+    MissingContact { query: String },
+    #[error("failed to persist contact: {0}")]
+    PersistContact(#[source] StorageError),
+    #[error("failed to read contacts: {0}")]
+    ReadContacts(#[source] StorageError),
     #[error("discovery duration must be greater than zero")]
     InvalidDiscoveryDuration,
     #[error("discovery announcement interval must be greater than zero")]
@@ -322,6 +372,7 @@ pub fn run<W: Write>(cli: Cli, mut writer: W) -> Result<(), CliError> {
         }
         CliCommand::Conversations => run_conversations(cli.config_path(), &mut writer)?,
         CliCommand::History(args) => run_history(cli.config_path(), args, &mut writer)?,
+        CliCommand::Contact(args) => run_contact(cli.config_path(), args, &mut writer)?,
     }
     Ok(())
 }
@@ -636,6 +687,139 @@ fn run_history<W: Write>(
     Ok(())
 }
 
+fn run_contact<W: Write>(
+    config_path: PathBuf,
+    args: ContactArgs,
+    writer: &mut W,
+) -> Result<(), CliError> {
+    match args.command {
+        ContactCommand::Add(args) => run_contact_add(config_path, args, writer),
+        ContactCommand::List => run_contact_list(config_path, writer),
+        ContactCommand::Show(args) => run_contact_show(config_path, args, writer),
+        ContactCommand::Trust(args) => run_contact_trust(config_path, args, writer),
+    }
+}
+
+fn run_contact_add<W: Write>(
+    config_path: PathBuf,
+    args: ContactAddArgs,
+    writer: &mut W,
+) -> Result<(), CliError> {
+    let alias = validate_cli_contact_alias(args.alias)?;
+    let fingerprint = parse_fingerprint(&args.fingerprint)?;
+    let storage = open_storage(config_path)?;
+    let contact = storage
+        .upsert_contact(ContactUpsert { alias, fingerprint })
+        .map_err(CliError::PersistContact)?;
+
+    writeln!(
+        writer,
+        "contact: stored alias={} fingerprint={}",
+        contact.alias,
+        fingerprint_hex(&contact.fingerprint)
+    )?;
+    write_contact_header(writer)?;
+    write_contact(writer, &contact)?;
+    Ok(())
+}
+
+fn run_contact_list<W: Write>(config_path: PathBuf, writer: &mut W) -> Result<(), CliError> {
+    let storage = open_storage(config_path)?;
+    let contacts = storage.list_contacts().map_err(CliError::ReadContacts)?;
+
+    writeln!(writer, "contacts: {}", contacts.len())?;
+    write_contact_header(writer)?;
+    for contact in contacts {
+        write_contact(writer, &contact)?;
+    }
+    Ok(())
+}
+
+fn run_contact_show<W: Write>(
+    config_path: PathBuf,
+    args: ContactLookupArgs,
+    writer: &mut W,
+) -> Result<(), CliError> {
+    let storage = open_storage(config_path)?;
+    let contact = find_contact(&storage, &args.query)?;
+
+    writeln!(
+        writer,
+        "contact: alias={} fingerprint={}",
+        contact.alias,
+        fingerprint_hex(&contact.fingerprint)
+    )?;
+    write_contact_header(writer)?;
+    write_contact(writer, &contact)?;
+    Ok(())
+}
+
+fn run_contact_trust<W: Write>(
+    config_path: PathBuf,
+    args: ContactLookupArgs,
+    writer: &mut W,
+) -> Result<(), CliError> {
+    let storage = open_storage(config_path)?;
+    let contact = find_contact(&storage, &args.query)?;
+    let trusted = storage
+        .trust_contact(contact.fingerprint)
+        .map_err(CliError::PersistContact)?
+        .ok_or_else(|| CliError::MissingContact { query: args.query })?;
+
+    writeln!(
+        writer,
+        "contact: trusted alias={} fingerprint={}",
+        trusted.alias,
+        fingerprint_hex(&trusted.fingerprint)
+    )?;
+    write_contact_header(writer)?;
+    write_contact(writer, &trusted)?;
+    Ok(())
+}
+
+fn find_contact(storage: &Storage, query: &str) -> Result<ContactRecord, CliError> {
+    if query.len() == 64 && query.bytes().all(|byte| hex_value(byte).is_some()) {
+        let fingerprint = parse_fingerprint(query)?;
+        return storage
+            .get_contact_by_fingerprint(fingerprint)
+            .map_err(CliError::ReadContacts)?
+            .ok_or_else(|| CliError::MissingContact {
+                query: query.to_owned(),
+            });
+    }
+
+    validate_cli_contact_alias(query.to_owned())?;
+    storage
+        .get_contact_by_alias(query)
+        .map_err(CliError::ReadContacts)?
+        .ok_or_else(|| CliError::MissingContact {
+            query: query.to_owned(),
+        })
+}
+
+fn write_contact_header<W: Write>(writer: &mut W) -> Result<(), io::Error> {
+    writeln!(
+        writer,
+        "alias\tfingerprint\tpublic_key_present\ttrust_state\tcreated_at\tupdated_at"
+    )
+}
+
+fn write_contact<W: Write>(
+    writer: &mut W,
+    contact: &ContactRecord,
+) -> Result<(), io::Error> {
+    writeln!(
+        writer,
+        "{}\t{}\t{}\t{}\t{}\t{}",
+        contact.alias,
+        fingerprint_hex(&contact.fingerprint),
+        contact.public_key_present,
+        contact_trust_state_label(contact.trust_state),
+        contact.created_at,
+        contact.updated_at
+    )
+}
+
 fn conversation_error(
     error: ConversationEngineError,
     requested_uuid: [u8; 16],
@@ -648,6 +832,13 @@ fn conversation_error(
             conversation_uuid: uuid_hex(&requested_uuid),
         },
         error => CliError::ReadConversation(error),
+    }
+}
+
+fn contact_trust_state_label(state: ContactTrustState) -> &'static str {
+    match state {
+        ContactTrustState::Untrusted => "untrusted",
+        ContactTrustState::Trusted => "trusted",
     }
 }
 
@@ -747,6 +938,19 @@ fn parse_fingerprint(input: &str) -> Result<Fingerprint, CliError> {
         fingerprint[index] = (high << 4) | low;
     }
     Ok(fingerprint)
+}
+
+fn validate_cli_contact_alias(alias: String) -> Result<String, CliError> {
+    if alias.is_empty()
+        || alias.trim() != alias
+        || alias.len() > 64
+        || alias
+            .chars()
+            .any(|character| character.is_control() || character == '\t')
+    {
+        return Err(CliError::InvalidContactAlias { alias });
+    }
+    Ok(alias)
 }
 
 fn parse_hash(input: &str) -> Result<[u8; 32], CliError> {
@@ -986,6 +1190,7 @@ mod tests {
         assert!(help.contains("send"));
         assert!(help.contains("conversations"));
         assert!(help.contains("history"));
+        assert!(help.contains("contact"));
 
         let mut command = Cli::command_for_help();
         let discover = command
@@ -1050,6 +1255,32 @@ mod tests {
             cli.command(),
             CliCommand::History(HistoryArgs {
                 conversation: "11111111-1111-4111-8111-111111111111".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_contact_add_subcommand() {
+        let cli = Cli::parse_from([
+            "decentra-chat",
+            "--config",
+            "config.toml",
+            "contact",
+            "add",
+            "--alias",
+            "alice",
+            "--fingerprint",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ]);
+
+        assert_eq!(
+            cli.command(),
+            CliCommand::Contact(ContactArgs {
+                command: ContactCommand::Add(ContactAddArgs {
+                    alias: "alice".to_owned(),
+                    fingerprint: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        .to_owned(),
+                }),
             })
         );
     }
@@ -1263,6 +1494,135 @@ storage_path = "{}"
         assert!(output.contains("conversations: 1"));
         assert!(output.contains("conversation_uuid\tcreated_at\tupdated_at"));
         assert!(output.contains("11111111111141118111111111111111"));
+    }
+
+    #[test]
+    fn contact_commands_add_list_show_and_trust() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage_path = dir.path().join("chat.sqlite3");
+        let config_path = write_config(dir.path(), "config.toml", &storage_path);
+        let fingerprint = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+        let mut add_output = Vec::new();
+        run_from(
+            [
+                "decentra-chat",
+                "--config",
+                config_path.to_str().expect("utf-8 path"),
+                "contact",
+                "add",
+                "--alias",
+                "alice",
+                "--fingerprint",
+                fingerprint,
+            ],
+            &mut add_output,
+        )
+        .expect("add contact");
+        let add_output = String::from_utf8(add_output).expect("output is UTF-8");
+        assert!(add_output.contains("contact: stored alias=alice"));
+        assert!(add_output.contains("\tfalse\tuntrusted\t"));
+
+        let mut trust_output = Vec::new();
+        run_from(
+            [
+                "decentra-chat",
+                "--config",
+                config_path.to_str().expect("utf-8 path"),
+                "contact",
+                "trust",
+                "alice",
+            ],
+            &mut trust_output,
+        )
+        .expect("trust contact");
+        let trust_output = String::from_utf8(trust_output).expect("output is UTF-8");
+        assert!(trust_output.contains("contact: trusted alias=alice"));
+        assert!(trust_output.contains("\tfalse\ttrusted\t"));
+
+        let mut list_output = Vec::new();
+        run_from(
+            [
+                "decentra-chat",
+                "--config",
+                config_path.to_str().expect("utf-8 path"),
+                "contact",
+                "list",
+            ],
+            &mut list_output,
+        )
+        .expect("list contacts");
+        let list_output = String::from_utf8(list_output).expect("output is UTF-8");
+        assert!(list_output.contains("contacts: 1"));
+        assert!(list_output.contains("alias\tfingerprint\tpublic_key_present\ttrust_state"));
+        assert!(list_output.contains(&format!("alice\t{fingerprint}\tfalse\ttrusted")));
+
+        let mut show_output = Vec::new();
+        run_from(
+            [
+                "decentra-chat",
+                "--config",
+                config_path.to_str().expect("utf-8 path"),
+                "contact",
+                "show",
+                fingerprint,
+            ],
+            &mut show_output,
+        )
+        .expect("show contact");
+        let show_output = String::from_utf8(show_output).expect("output is UTF-8");
+        assert!(show_output.contains("contact: alias=alice"));
+        assert!(show_output.contains(&format!("alice\t{fingerprint}\tfalse\ttrusted")));
+    }
+
+    #[test]
+    fn contact_alias_conflict_is_actionable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage_path = dir.path().join("chat.sqlite3");
+        let config_path = write_config(dir.path(), "config.toml", &storage_path);
+        let mut output = Vec::new();
+        run_from(
+            [
+                "decentra-chat",
+                "--config",
+                config_path.to_str().expect("utf-8 path"),
+                "contact",
+                "add",
+                "--alias",
+                "alice",
+                "--fingerprint",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ],
+            &mut output,
+        )
+        .expect("add first contact");
+
+        let error = run_from(
+            [
+                "decentra-chat",
+                "--config",
+                config_path.to_str().expect("utf-8 path"),
+                "contact",
+                "add",
+                "--alias",
+                "ALICE",
+                "--fingerprint",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ],
+            Vec::new(),
+        )
+        .expect_err("alias conflict");
+
+        assert!(error.to_string().contains("already belongs to fingerprint"));
+    }
+
+    #[test]
+    fn invalid_contact_inputs_are_actionable() {
+        let error = validate_cli_contact_alias(" alice ".to_owned()).expect_err("invalid alias");
+        assert!(error.to_string().contains("without tabs, newlines"));
+
+        let error = parse_fingerprint("not-hex").expect_err("invalid fingerprint");
+        assert!(error.to_string().contains("64 hex characters"));
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -12,6 +12,7 @@ const MIGRATION_001: &str = "001_peer_keys";
 const MIGRATION_002: &str = "002_message_acks";
 const MIGRATION_003: &str = "003_conversation_messages";
 const MIGRATION_004: &str = "004_reply_metadata";
+const MIGRATION_005: &str = "005_contacts";
 
 /// SQLite-backed local storage for DecentraChat peer data.
 pub struct Storage {
@@ -36,6 +37,43 @@ pub struct PeerKeyUpsert {
     pub nick: Option<String>,
     pub public_key: Vec<u8>,
     pub last_seen: i64,
+}
+
+/// Local trust state for a pinned contact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContactTrustState {
+    Untrusted,
+    Trusted,
+}
+
+impl ContactTrustState {
+    fn from_str(value: &str) -> Result<Self, StorageError> {
+        match value {
+            "untrusted" => Ok(Self::Untrusted),
+            "trusted" => Ok(Self::Trusted),
+            value => Err(StorageError::InvalidContactTrustState {
+                value: value.to_owned(),
+            }),
+        }
+    }
+}
+
+/// SQLite-backed contact and fingerprint-pinning record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContactRecord {
+    pub alias: String,
+    pub fingerprint: Fingerprint,
+    pub public_key_present: bool,
+    pub trust_state: ContactTrustState,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// Data accepted by the contact repository upsert operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContactUpsert {
+    pub alias: String,
+    pub fingerprint: Fingerprint,
 }
 
 /// Persisted delivery acknowledgement for one outbound chat message.
@@ -125,6 +163,19 @@ pub enum StorageError {
     Repository(#[source] rusqlite::Error),
     #[error("peer public key must not be empty")]
     EmptyPublicKey,
+    #[error("contact alias must not be empty")]
+    EmptyContactAlias,
+    #[error(
+        "contact alias `{alias}` is invalid: use 1-64 visible characters without tabs, newlines, or leading/trailing spaces"
+    )]
+    InvalidContactAlias { alias: String },
+    #[error("contact alias `{alias}` already belongs to fingerprint {existing_fingerprint}")]
+    ContactAliasConflict {
+        alias: String,
+        existing_fingerprint: String,
+    },
+    #[error("stored contact trust state `{value}` is unsupported")]
+    InvalidContactTrustState { value: String },
     #[error("message ACK signature must not be empty")]
     EmptyAckSignature,
     #[error("stored message UUID must be 16 bytes, got {len}")]
@@ -197,6 +248,15 @@ impl Storage {
                 ],
             )
             .map_err(StorageError::Repository)?;
+        self.connection
+            .execute(
+                "UPDATE contacts
+                 SET public_key_present = 1,
+                     updated_at = MAX(updated_at, ?2)
+                 WHERE fingerprint = ?1",
+                params![&upsert.fingerprint[..], now],
+            )
+            .map_err(StorageError::Repository)?;
 
         self.get_peer_key(upsert.fingerprint)?
             .ok_or_else(|| StorageError::Repository(rusqlite::Error::QueryReturnedNoRows))
@@ -219,6 +279,134 @@ impl Storage {
             .map_err(StorageError::Repository)?
             .map(validate_record)
             .transpose()
+    }
+
+    /// Insert or update a contact alias for a fingerprint.
+    pub fn upsert_contact(
+        &self,
+        upsert: ContactUpsert,
+    ) -> Result<ContactRecord, StorageError> {
+        let alias = validate_contact_alias(upsert.alias)?;
+        if let Some(existing) = self.get_contact_by_alias(&alias)? {
+            if existing.fingerprint != upsert.fingerprint {
+                return Err(StorageError::ContactAliasConflict {
+                    alias,
+                    existing_fingerprint: fingerprint_hex(&existing.fingerprint),
+                });
+            }
+        }
+
+        let now = unix_timestamp()?;
+        let public_key_present = self.peer_key_exists(upsert.fingerprint)?;
+        self.connection
+            .execute(
+                "INSERT INTO contacts (
+                    fingerprint, alias, public_key_present, trust_state, created_at, updated_at
+                ) VALUES (?1, ?2, ?3, 'untrusted', ?4, ?4)
+                ON CONFLICT(fingerprint) DO UPDATE SET
+                    alias = excluded.alias,
+                    public_key_present = excluded.public_key_present,
+                    updated_at = excluded.updated_at",
+                params![
+                    &upsert.fingerprint[..],
+                    alias,
+                    public_key_present,
+                    now,
+                ],
+            )
+            .map_err(StorageError::Repository)?;
+
+        self.get_contact_by_fingerprint(upsert.fingerprint)?
+            .ok_or_else(|| StorageError::Repository(rusqlite::Error::QueryReturnedNoRows))
+    }
+
+    /// Mark a contact as explicitly trusted/pinned.
+    pub fn trust_contact(
+        &self,
+        fingerprint: Fingerprint,
+    ) -> Result<Option<ContactRecord>, StorageError> {
+        let now = unix_timestamp()?;
+        self.connection
+            .execute(
+                "UPDATE contacts
+                 SET trust_state = 'trusted',
+                     public_key_present = EXISTS(
+                        SELECT 1 FROM peer_keys WHERE peer_keys.fingerprint = contacts.fingerprint
+                     ),
+                     updated_at = ?2
+                 WHERE fingerprint = ?1",
+                params![&fingerprint[..], now],
+            )
+            .map_err(StorageError::Repository)?;
+        self.get_contact_by_fingerprint(fingerprint)
+    }
+
+    /// Fetch a contact by fingerprint.
+    pub fn get_contact_by_fingerprint(
+        &self,
+        fingerprint: Fingerprint,
+    ) -> Result<Option<ContactRecord>, StorageError> {
+        self.connection
+            .query_row(
+                "SELECT alias, fingerprint, public_key_present, trust_state, created_at, updated_at
+                 FROM contacts
+                 WHERE fingerprint = ?1",
+                params![&fingerprint[..]],
+                row_to_contact,
+            )
+            .optional()
+            .map_err(StorageError::Repository)?
+            .map(validate_contact_record)
+            .transpose()
+    }
+
+    /// Fetch a contact by alias.
+    pub fn get_contact_by_alias(
+        &self,
+        alias: &str,
+    ) -> Result<Option<ContactRecord>, StorageError> {
+        let alias = validate_contact_alias(alias.to_owned())?;
+        self.connection
+            .query_row(
+                "SELECT alias, fingerprint, public_key_present, trust_state, created_at, updated_at
+                 FROM contacts
+                 WHERE alias = ?1 COLLATE NOCASE",
+                params![alias],
+                row_to_contact,
+            )
+            .optional()
+            .map_err(StorageError::Repository)?
+            .map(validate_contact_record)
+            .transpose()
+    }
+
+    /// List contacts in deterministic alias order.
+    pub fn list_contacts(&self) -> Result<Vec<ContactRecord>, StorageError> {
+        let mut statement = self
+            .connection
+            .prepare(
+                "SELECT alias, fingerprint, public_key_present, trust_state, created_at, updated_at
+                 FROM contacts
+                 ORDER BY alias COLLATE NOCASE, fingerprint",
+            )
+            .map_err(StorageError::Repository)?;
+
+        let contacts = statement
+            .query_map([], row_to_contact)
+            .map_err(StorageError::Repository)?
+            .map(|row| row.map_err(StorageError::Repository).and_then(validate_contact_record))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(contacts)
+    }
+
+    fn peer_key_exists(&self, fingerprint: Fingerprint) -> Result<bool, StorageError> {
+        self.connection
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM peer_keys WHERE fingerprint = ?1)",
+                params![&fingerprint[..]],
+                |row| row.get::<_, bool>(0),
+            )
+            .map_err(StorageError::Repository)
     }
 
     /// Insert or update the signed ACK state for an outbound message UUID.
@@ -566,7 +754,25 @@ fn apply_migrations(connection: &mut Connection) -> Result<(), StorageError> {
                 ON accepted_chat_messages(conversation_uuid);
 
             CREATE INDEX IF NOT EXISTS idx_accepted_chat_messages_previous_hash
-                ON accepted_chat_messages(conversation_uuid, previous_hash);",
+                ON accepted_chat_messages(conversation_uuid, previous_hash);
+
+            CREATE TABLE IF NOT EXISTS contacts (
+                fingerprint BLOB PRIMARY KEY CHECK(length(fingerprint) = 32),
+                alias TEXT NOT NULL COLLATE NOCASE UNIQUE CHECK(length(alias) BETWEEN 1 AND 64),
+                public_key_present INTEGER NOT NULL DEFAULT 0 CHECK(public_key_present IN (0, 1)),
+                trust_state TEXT NOT NULL DEFAULT 'untrusted'
+                    CHECK(trust_state IN ('untrusted', 'trusted')),
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_contacts_alias
+                ON contacts(alias COLLATE NOCASE);
+
+            UPDATE contacts
+            SET public_key_present = EXISTS(
+                SELECT 1 FROM peer_keys WHERE peer_keys.fingerprint = contacts.fingerprint
+            );",
         )
         .map_err(StorageError::Migration)?;
 
@@ -588,7 +794,13 @@ fn apply_migrations(connection: &mut Connection) -> Result<(), StorageError> {
     }
 
     let now = unix_timestamp()?;
-    for migration in [MIGRATION_001, MIGRATION_002, MIGRATION_003, MIGRATION_004] {
+    for migration in [
+        MIGRATION_001,
+        MIGRATION_002,
+        MIGRATION_003,
+        MIGRATION_004,
+        MIGRATION_005,
+    ] {
         transaction
             .execute(
                 "INSERT OR IGNORE INTO schema_migrations (name, applied_at) VALUES (?1, ?2)",
@@ -616,6 +828,20 @@ fn column_exists(
     Ok(columns.iter().any(|name| name == column))
 }
 
+fn row_to_contact(row: &rusqlite::Row<'_>) -> rusqlite::Result<ContactRecord> {
+    let trust_state = row
+        .get::<_, String>(3)
+        .and_then(|value| ContactTrustState::from_str(&value).map_err(storage_error_to_sql_error))?;
+    Ok(ContactRecord {
+        alias: row.get(0)?,
+        fingerprint: vec_to_fingerprint(row.get(1)?).map_err(storage_error_to_sql_error)?,
+        public_key_present: row.get(2)?,
+        trust_state,
+        created_at: row.get(4)?,
+        updated_at: row.get(5)?,
+    })
+}
+
 fn row_to_peer_key(row: &rusqlite::Row<'_>) -> rusqlite::Result<PeerKeyRecord> {
     Ok(PeerKeyRecord {
         fingerprint: vec_to_fingerprint(row.get(0)?).map_err(|error| {
@@ -631,6 +857,26 @@ fn row_to_peer_key(row: &rusqlite::Row<'_>) -> rusqlite::Result<PeerKeyRecord> {
         last_seen: row.get(4)?,
         updated_at: row.get(5)?,
     })
+}
+
+fn validate_contact_record(record: ContactRecord) -> Result<ContactRecord, StorageError> {
+    validate_contact_alias(record.alias.clone())?;
+    Ok(record)
+}
+
+fn validate_contact_alias(alias: String) -> Result<String, StorageError> {
+    if alias.is_empty() {
+        return Err(StorageError::EmptyContactAlias);
+    }
+    if alias.trim() != alias
+        || alias.len() > 64
+        || alias
+            .chars()
+            .any(|character| character.is_control() || character == '\t')
+    {
+        return Err(StorageError::InvalidContactAlias { alias });
+    }
+    Ok(alias)
 }
 
 fn row_to_message_ack(row: &rusqlite::Row<'_>) -> rusqlite::Result<MessageAckRecord> {
@@ -895,6 +1141,23 @@ fn unix_timestamp() -> Result<i64, StorageError> {
     i64::try_from(duration.as_secs()).map_err(|_| StorageError::InvalidSystemTime)
 }
 
+fn fingerprint_hex(fingerprint: &Fingerprint) -> String {
+    let mut output = String::with_capacity(64);
+    for byte in fingerprint {
+        output.push(nibble_hex(byte >> 4));
+        output.push(nibble_hex(byte & 0x0f));
+    }
+    output
+}
+
+fn nibble_hex(value: u8) -> char {
+    match value {
+        0..=9 => (b'0' + value) as char,
+        10..=15 => (b'a' + value - 10) as char,
+        _ => unreachable!("nibble value is always <= 15"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -939,12 +1202,18 @@ mod tests {
             .connection
             .query_row(
                 "SELECT COUNT(*) FROM schema_migrations
-                 WHERE name IN (?1, ?2, ?3, ?4)",
-                params![MIGRATION_001, MIGRATION_002, MIGRATION_003, MIGRATION_004],
+                 WHERE name IN (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    MIGRATION_001,
+                    MIGRATION_002,
+                    MIGRATION_003,
+                    MIGRATION_004,
+                    MIGRATION_005
+                ],
                 |row| row.get(0),
             )
             .expect("query migration count");
-        assert_eq!(migration_count, 4);
+        assert_eq!(migration_count, 5);
         assert!(db_path.exists());
     }
 
@@ -960,7 +1229,7 @@ mod tests {
             .connection
             .query_row("SELECT COUNT(*) FROM schema_migrations", [], |row| row.get(0))
             .expect("query migration count");
-        assert_eq!(migration_count, 4);
+        assert_eq!(migration_count, 5);
     }
 
     #[test]
@@ -983,6 +1252,71 @@ mod tests {
         assert_eq!(fetched.public_key, vec![1, 2, 3, 4]);
         assert_eq!(fetched.first_seen, 100);
         assert_eq!(fetched.last_seen, 100);
+    }
+
+    #[test]
+    fn upsert_and_list_contacts_preserves_trust_and_tracks_public_key_presence() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = Storage::open(dir.path().join("dc.sqlite3")).expect("open storage");
+        let fingerprint = [0xaa; 32];
+
+        let contact = storage
+            .upsert_contact(ContactUpsert {
+                alias: "alice".to_owned(),
+                fingerprint,
+            })
+            .expect("insert contact");
+        assert_eq!(contact.trust_state, ContactTrustState::Untrusted);
+        assert!(!contact.public_key_present);
+
+        storage
+            .trust_contact(fingerprint)
+            .expect("trust contact")
+            .expect("stored contact");
+        storage
+            .upsert_peer_key(upsert(fingerprint, Some("alice"), 100))
+            .expect("insert peer key");
+        let updated = storage
+            .upsert_contact(ContactUpsert {
+                alias: "alice-renamed".to_owned(),
+                fingerprint,
+            })
+            .expect("update contact");
+
+        assert_eq!(updated.trust_state, ContactTrustState::Trusted);
+        assert!(updated.public_key_present);
+        assert_eq!(
+            storage.list_contacts().expect("list contacts"),
+            vec![updated]
+        );
+    }
+
+    #[test]
+    fn contact_alias_cannot_move_to_another_fingerprint() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = Storage::open(dir.path().join("dc.sqlite3")).expect("open storage");
+        storage
+            .upsert_contact(ContactUpsert {
+                alias: "alice".to_owned(),
+                fingerprint: [0xaa; 32],
+            })
+            .expect("insert contact");
+
+        let error = storage
+            .upsert_contact(ContactUpsert {
+                alias: "ALICE".to_owned(),
+                fingerprint: [0xbb; 32],
+            })
+            .expect_err("alias conflict");
+
+        assert!(error.to_string().contains("already belongs to fingerprint"));
+    }
+
+    #[test]
+    fn invalid_contact_alias_is_actionable() {
+        let error = validate_contact_alias(" alice ".to_owned()).expect_err("invalid alias");
+
+        assert!(error.to_string().contains("without tabs, newlines"));
     }
 
     #[test]
@@ -1100,7 +1434,7 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM schema_migrations", [], |row| row.get(0))
             .expect("query migration count");
 
-        assert_eq!(migration_count, 4);
+        assert_eq!(migration_count, 5);
         storage
             .upsert_message_ack(MessageAckUpsert {
                 message_uuid: [0x44; 16],
@@ -1117,6 +1451,12 @@ mod tests {
                 [0x12; 32],
             ))
             .expect("insert accepted message after migration");
+        storage
+            .upsert_contact(ContactUpsert {
+                alias: "alice".to_owned(),
+                fingerprint: [0x77; 32],
+            })
+            .expect("insert contact after migration");
     }
 
     #[test]

--- a/tests/cli_e2e.rs
+++ b/tests/cli_e2e.rs
@@ -71,6 +71,87 @@ fn discover_runs_with_bounded_loopback_runtime_and_exits_cleanly() {
 }
 
 #[test]
+fn contact_book_add_list_show_and_trust_work_through_public_cli() {
+    let fixture = TestFixture::new("contact-book");
+    let storage_path = fixture.path("state/contacts.sqlite3");
+    let config_path = fixture.write_config("contacts.toml", 45102, &storage_path);
+    let fingerprint = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    let add = fixture.cli(
+        [
+            "--config",
+            path_arg(&config_path),
+            "contact",
+            "add",
+            "--alias",
+            "alice",
+            "--fingerprint",
+            fingerprint,
+        ],
+        "contact add alice",
+    );
+    assert_success(&add, "contact add alice");
+    let add_stdout = stdout(&add);
+    assert!(add_stdout.contains("contact: stored alias=alice"), "{add_stdout}");
+    assert!(
+        add_stdout.contains(&format!("alice\t{fingerprint}\tfalse\tuntrusted")),
+        "{add_stdout}"
+    );
+
+    let trust = fixture.cli(
+        [
+            "--config",
+            path_arg(&config_path),
+            "contact",
+            "trust",
+            "alice",
+        ],
+        "contact trust alice",
+    );
+    assert_success(&trust, "contact trust alice");
+    let trust_stdout = stdout(&trust);
+    assert!(trust_stdout.contains("contact: trusted alias=alice"), "{trust_stdout}");
+    assert!(
+        trust_stdout.contains(&format!("alice\t{fingerprint}\tfalse\ttrusted")),
+        "{trust_stdout}"
+    );
+
+    let list = fixture.cli(
+        ["--config", path_arg(&config_path), "contact", "list"],
+        "contact list",
+    );
+    assert_success(&list, "contact list");
+    let list_stdout = stdout(&list);
+    assert!(list_stdout.contains("contacts: 1"), "{list_stdout}");
+    assert!(
+        list_stdout.contains("alias\tfingerprint\tpublic_key_present\ttrust_state"),
+        "{list_stdout}"
+    );
+    assert!(
+        list_stdout.contains(&format!("alice\t{fingerprint}\tfalse\ttrusted")),
+        "{list_stdout}"
+    );
+
+    let show = fixture.cli(
+        [
+            "--config",
+            path_arg(&config_path),
+            "contact",
+            "show",
+            fingerprint,
+        ],
+        "contact show alice by fingerprint",
+    );
+    assert_success(&show, "contact show alice by fingerprint");
+    let show_stdout = stdout(&show);
+    assert!(show_stdout.contains("contact: alias=alice"), "{show_stdout}");
+    assert!(
+        show_stdout.contains(&format!("alice\t{fingerprint}\tfalse\ttrusted")),
+        "{show_stdout}"
+    );
+}
+
+#[test]
 fn key_exchange_send_ack_and_history_work_through_public_cli() {
     let fixture = TestFixture::new("chat-roundtrip");
     let alice_storage = fixture.path("alice.sqlite3");


### PR DESCRIPTION
## Summary
- add SQLite-backed contact records with alias uniqueness, public-key presence, trust state, and idempotent migration support
- add `contact add/list/show/trust` CLI commands with fingerprint and alias validation while preserving existing raw-fingerprint workflows
- add storage, CLI, black-box e2e coverage and update the CLI guide

## Verification
- `RUST_MIN_STACK=16777216 cargo test --test cli_e2e`
- `RUST_MIN_STACK=16777216 cargo test`
- `git diff --check`

Note: `cargo fmt`/`rustfmt` and `cargo clippy` are not installed in this runner.

Closes #52