### PR TITLE
feat: onboard discovered peers into contacts

### DIFF
--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -201,6 +201,30 @@ cargo run -- --config ./bob.toml key-request --peer 127.0.0.1:52002
 When it is missing, the CLI exits with an error that points back to
 `key-request`.
 
+## Onboarding a Discovered Peer
+
+`onboard` is the shortest path from a discovery row to a trusted local contact.
+Pass the advertised peer address, advertised fingerprint, and the alias you want
+to use locally. The command runs the same TCP key-exchange protocol as
+`key-request`, verifies that the fetched public key matches the advertised
+fingerprint, stores the peer key, and creates or updates the contact record.
+
+```sh
+cargo run -- --config ./alice.toml onboard \
+  --alias bob \
+  --fingerprint "$BOB_FINGERPRINT" \
+  --peer 127.0.0.1:52002 \
+  --trust
+```
+
+`--trust` is the explicit non-interactive trust decision. Omit it to fetch and
+store the key as an untrusted contact, then run `contact trust bob` after
+verifying the fingerprint out of band.
+
+If an alias already belongs to a different fingerprint, onboarding fails before
+requesting a new key. This prevents a discovered fingerprint change from
+silently replacing an existing pin.
+
 ## Contact Book and Trust
 
 Contacts are local aliases pinned to peer fingerprints in the configured SQLite

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,6 +60,8 @@ pub enum CliCommand {
     KeyRequest(KeyRequestArgs),
     /// Run bounded UDP multicast discovery and print the visible peer list.
     Discover(DiscoverArgs),
+    /// Request a discovered peer key and store it as a local contact.
+    Onboard(OnboardArgs),
     /// Receive and persist one encrypted signed message from a known peer.
     Receive(ReceiveArgs),
     /// Send one encrypted signed message to a known peer and persist its ACK.
@@ -126,6 +128,22 @@ pub struct DiscoverArgs {
     /// Announcement interval in milliseconds.
     #[arg(long, default_value_t = 1_000)]
     announce_interval_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
+pub struct OnboardArgs {
+    /// Stable local alias for this peer.
+    #[arg(long, value_name = "ALIAS")]
+    alias: String,
+    /// Hex-encoded 32-byte fingerprint advertised by discovery.
+    #[arg(long, value_name = "HEX")]
+    fingerprint: String,
+    /// TCP peer address serving the key-exchange protocol.
+    #[arg(long, value_name = "ADDR")]
+    peer: SocketAddr,
+    /// Explicitly trust/pin the fetched key for this alias.
+    #[arg(long)]
+    trust: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
@@ -246,6 +264,22 @@ pub enum CliError {
         "contact `{query}` is not in local storage; run `contact add --alias <ALIAS> --fingerprint <HEX>` first"
     )]
     MissingContact { query: String },
+    #[error(
+        "contact alias `{alias}` is already pinned to fingerprint {existing_fingerprint}; refusing to replace it with {new_fingerprint}"
+    )]
+    ContactFingerprintChanged {
+        alias: String,
+        existing_fingerprint: String,
+        new_fingerprint: String,
+    },
+    #[error(
+        "peer at {peer} returned fingerprint {actual_fingerprint}, but discovery advertised {expected_fingerprint}; verify the peer before trusting it"
+    )]
+    OnboardFingerprintMismatch {
+        peer: SocketAddr,
+        expected_fingerprint: String,
+        actual_fingerprint: String,
+    },
     #[error("failed to persist contact: {0}")]
     PersistContact(#[source] StorageError),
     #[error("failed to read contacts: {0}")]
@@ -361,6 +395,10 @@ pub fn run<W: Write>(cli: Cli, mut writer: W) -> Result<(), CliError> {
         CliCommand::Discover(args) => {
             let runtime = runtime()?;
             runtime.block_on(run_discovery(cli.config_path(), args, &mut writer))?;
+        }
+        CliCommand::Onboard(args) => {
+            let runtime = runtime()?;
+            runtime.block_on(run_onboard(cli.config_path(), args, &mut writer))?;
         }
         CliCommand::Receive(args) => {
             let runtime = runtime()?;
@@ -526,6 +564,73 @@ pub async fn run_discovery<W: Write>(
     }
 
     write_peer_list(writer, &discovery.registry_snapshot(), Instant::now())?;
+    Ok(())
+}
+
+async fn run_onboard<W: Write>(
+    config_path: PathBuf,
+    args: OnboardArgs,
+    writer: &mut W,
+) -> Result<(), CliError> {
+    let alias = validate_cli_contact_alias(args.alias)?;
+    let expected_fingerprint = parse_fingerprint(&args.fingerprint)?;
+    let storage = open_storage(config_path)?;
+
+    if let Some(existing) = storage
+        .get_contact_by_alias(&alias)
+        .map_err(CliError::ReadContacts)?
+    {
+        if existing.fingerprint != expected_fingerprint {
+            return Err(CliError::ContactFingerprintChanged {
+                alias,
+                existing_fingerprint: fingerprint_hex(&existing.fingerprint),
+                new_fingerprint: fingerprint_hex(&expected_fingerprint),
+            });
+        }
+    }
+
+    let peer = key_exchange::request_peer_key(args.peer, &storage).await?;
+    if peer.fingerprint != expected_fingerprint {
+        return Err(CliError::OnboardFingerprintMismatch {
+            peer: args.peer,
+            expected_fingerprint: fingerprint_hex(&expected_fingerprint),
+            actual_fingerprint: fingerprint_hex(&peer.fingerprint),
+        });
+    }
+
+    let mut contact = storage
+        .upsert_contact(ContactUpsert {
+            alias,
+            fingerprint: expected_fingerprint,
+        })
+        .map_err(CliError::PersistContact)?;
+    if args.trust {
+        contact = storage
+            .trust_contact(expected_fingerprint)
+            .map_err(CliError::PersistContact)?
+            .ok_or_else(|| CliError::MissingContact {
+                query: fingerprint_hex(&expected_fingerprint),
+            })?;
+    }
+
+    writeln!(
+        writer,
+        "onboard: stored alias={} fingerprint={} peer={}",
+        contact.alias,
+        fingerprint_hex(&contact.fingerprint),
+        args.peer
+    )?;
+    if args.trust {
+        writeln!(writer, "onboard: trusted=true")?;
+    } else {
+        writeln!(
+            writer,
+            "onboard: trusted=false; run `contact trust {}` after verifying the fingerprint",
+            contact.alias
+        )?;
+    }
+    write_contact_header(writer)?;
+    write_contact(writer, &contact)?;
     Ok(())
 }
 

--- a/tests/cli_e2e.rs
+++ b/tests/cli_e2e.rs
@@ -152,6 +152,141 @@ fn contact_book_add_list_show_and_trust_work_through_public_cli() {
 }
 
 #[test]
+fn onboard_fetches_peer_key_stores_contact_and_trusts_when_explicit() {
+    let fixture = TestFixture::new("onboard-success");
+    let storage_path = fixture.path("state/onboard.sqlite3");
+    let config_path = fixture.write_config("onboard.toml", 45103, &storage_path);
+    let bob_public = fixture.path("bob.public");
+    let bob_secret = fixture.path("bob.secret");
+
+    let bob_keygen = fixture.cli(
+        [
+            "keygen",
+            "--secret-key",
+            path_arg(&bob_secret),
+            "--public-key",
+            path_arg(&bob_public),
+        ],
+        "bob keygen for onboarding",
+    );
+    assert_success(&bob_keygen, "bob keygen for onboarding");
+    let bob_fingerprint = fingerprint_from_keygen(&stdout(&bob_keygen));
+
+    let key_addr = format!("127.0.0.1:{}", free_tcp_port());
+    let mut bob_key_server = fixture.spawn_cli(
+        [
+            "key-serve",
+            "--public-key",
+            path_arg(&bob_public),
+            "--listen",
+            key_addr.as_str(),
+            "--duration-ms",
+            "10000",
+        ],
+        "bob key-serve for onboarding",
+    );
+
+    let onboard = fixture.eventually_cli(
+        [
+            "--config",
+            path_arg(&config_path),
+            "onboard",
+            "--alias",
+            "bob",
+            "--fingerprint",
+            bob_fingerprint.as_str(),
+            "--peer",
+            key_addr.as_str(),
+            "--trust",
+        ],
+        "onboard bob",
+    );
+    assert_success(&onboard, "onboard bob");
+    bob_key_server.kill_and_wait();
+
+    let onboard_stdout = stdout(&onboard);
+    assert!(
+        onboard_stdout.contains("onboard: stored alias=bob"),
+        "{onboard_stdout}"
+    );
+    assert!(
+        onboard_stdout.contains("onboard: trusted=true"),
+        "{onboard_stdout}"
+    );
+    assert!(
+        onboard_stdout.contains(&format!("bob\t{bob_fingerprint}\ttrue\ttrusted")),
+        "{onboard_stdout}"
+    );
+
+    let show = fixture.cli(
+        ["--config", path_arg(&config_path), "contact", "show", "bob"],
+        "show onboarded bob",
+    );
+    assert_success(&show, "show onboarded bob");
+    let show_stdout = stdout(&show);
+    assert!(
+        show_stdout.contains(&format!("bob\t{bob_fingerprint}\ttrue\ttrusted")),
+        "{show_stdout}"
+    );
+}
+
+#[test]
+fn onboard_refuses_alias_fingerprint_changes_before_rekeying() {
+    let fixture = TestFixture::new("onboard-fingerprint-change");
+    let storage_path = fixture.path("state/onboard.sqlite3");
+    let config_path = fixture.write_config("onboard.toml", 45104, &storage_path);
+    let old_fingerprint = "1111111111111111111111111111111111111111111111111111111111111111";
+    let new_fingerprint = "2222222222222222222222222222222222222222222222222222222222222222";
+
+    let add = fixture.cli(
+        [
+            "--config",
+            path_arg(&config_path),
+            "contact",
+            "add",
+            "--alias",
+            "bob",
+            "--fingerprint",
+            old_fingerprint,
+        ],
+        "seed bob contact",
+    );
+    assert_success(&add, "seed bob contact");
+
+    let failure = fixture.cli(
+        [
+            "--config",
+            path_arg(&config_path),
+            "onboard",
+            "--alias",
+            "bob",
+            "--fingerprint",
+            new_fingerprint,
+            "--peer",
+            "127.0.0.1:9",
+            "--trust",
+        ],
+        "onboard bob changed fingerprint",
+    );
+
+    assert!(
+        !failure.status.success(),
+        "onboard should fail on fingerprint change\nstdout:\n{}\nstderr:\n{}",
+        stdout(&failure),
+        stderr(&failure)
+    );
+    let stderr = stderr(&failure);
+    assert!(
+        stderr.contains("refusing to replace it"),
+        "stderr should explain fingerprint-change refusal: {stderr}"
+    );
+    assert!(
+        stderr.contains(old_fingerprint) && stderr.contains(new_fingerprint),
+        "stderr should include both fingerprints: {stderr}"
+    );
+}
+
+#[test]
 fn key_exchange_send_ack_and_history_work_through_public_cli() {
     let fixture = TestFixture::new("chat-roundtrip");
     let alice_storage = fixture.path("alice.sqlite3");


### PR DESCRIPTION
## Summary
- add an `onboard` CLI command that composes key exchange with contact creation
- verify discovered fingerprints before storing the contact and refuse alias fingerprint changes before re-keying
- support explicit non-interactive trust with `--trust` and document the onboarding path

## Verification
- `RUST_MIN_STACK=16777216 cargo test --test cli_e2e`
- `RUST_MIN_STACK=16777216 cargo test`
- `git diff --check`

Note: `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` are unavailable in this runner because cargo reports no such subcommand.

Closes #53