### PR TITLE
feat: add bounded chat session command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 socket2 = "0.5"
 thiserror = "1"
-tokio = { version = "1.0", features = ["io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.0", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 toml = "0.8"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cargo run -- --config ./config.toml status
 ```
 
 For a complete loopback walkthrough with two local identities, key exchange,
-message send/receive, delivery state, and conversation history, follow the
+message send/receive, bounded chat sessions, delivery state, and conversation history, follow the
 [CLI user guide](docs/CLI_GUIDE.md).
 
 Show the command surface at any time:

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -2,8 +2,8 @@
 
 The DecentraChat CLI is the current user-facing client. It can inspect local
 configuration, initialize storage, manage local contacts, run bounded LAN
-discovery, exchange public keys, send and receive one encrypted message, and
-read conversation history from SQLite.
+discovery, exchange public keys, send and receive encrypted messages, run a
+bounded stdin-driven chat session, and read conversation history from SQLite.
 
 The commands below describe what is implemented in `src/cli.rs` today. There is
 no TUI or long-running chat daemon yet.
@@ -228,9 +228,9 @@ silently replacing an existing pin.
 ## Contact Book and Trust
 
 Contacts are local aliases pinned to peer fingerprints in the configured SQLite
-store. They do not replace raw fingerprint workflows yet; `key-request`, `send`,
-`receive`, `conversations`, and `history` still accept the same fingerprint
-arguments as before.
+store. `chat` requires a trusted contact with a stored public key. The lower
+level `key-request`, `send`, `receive`, `conversations`, and `history`
+commands still accept the same fingerprint arguments as before.
 
 Add or update an alias for a fingerprint:
 
@@ -298,6 +298,28 @@ cargo run -- --config ./alice.toml send \
 When `--conversation` is omitted, `send` creates a new UUID v4. Use
 `--previous-hash` when appending to an existing message chain. The default
 previous hash is the zero hash, which starts a chain segment.
+
+## Bounded Chat Session
+
+`chat` opens one conversation with one trusted contact. It prints the current
+conversation history, listens for inbound messages until `--duration-ms`
+expires, and sends each non-empty stdin line through the same encrypted TCP path
+used by `send`. Sent messages are persisted with their ACK state, and received
+messages are persisted for later history reads.
+
+```sh
+printf 'first message\nsecond message\n' | cargo run -- --config ./alice.toml chat \
+  --secret-key ./alice.secret \
+  --contact bob \
+  --peer 127.0.0.1:52003 \
+  --listen 127.0.0.1:52004 \
+  --conversation 11111111-1111-4111-8111-111111111111 \
+  --duration-ms 30000
+```
+
+For loopback testing, start the peer's `chat` command first with the opposite
+`--peer` and `--listen` addresses. Close stdin on a receive-only session; it
+will continue polling inbound messages until the bounded duration expires.
 
 ## Delivery State and History
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,16 +21,20 @@ use crate::{
 use clap::{CommandFactory, Parser, Subcommand};
 use pgp::composed::SignedSecretKey;
 use rand::RngCore;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::{
     collections::HashMap,
     ffi::OsString,
     fs,
     io::{self, Write},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
     time::{Duration, Instant},
 };
 use thiserror::Error;
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    pin,
+};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -66,6 +70,8 @@ pub enum CliCommand {
     Receive(ReceiveArgs),
     /// Send one encrypted signed message to a known peer and persist its ACK.
     Send(SendArgs),
+    /// Run a bounded stdin-driven chat session with one trusted contact.
+    Chat(ChatArgs),
     /// List known conversations in local storage.
     Conversations,
     /// Show ordered message history for one conversation.
@@ -196,6 +202,28 @@ pub struct SendArgs {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
+pub struct ChatArgs {
+    /// Path to the serialized local secret key.
+    #[arg(long, value_name = "PATH")]
+    secret_key: PathBuf,
+    /// Trusted contact alias or fingerprint to chat with.
+    #[arg(long, value_name = "FINGERPRINT_OR_ALIAS")]
+    contact: String,
+    /// TCP peer address accepting chat messages.
+    #[arg(long, value_name = "ADDR")]
+    peer: SocketAddr,
+    /// TCP address used to receive chat messages during the session.
+    #[arg(long, value_name = "ADDR")]
+    listen: SocketAddr,
+    /// Conversation UUID as 32 hex characters or canonical hyphenated UUID.
+    #[arg(long, value_name = "UUID")]
+    conversation: String,
+    /// Bounded session length in milliseconds.
+    #[arg(long, default_value_t = 30_000)]
+    duration_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
 pub struct HistoryArgs {
     /// Conversation UUID as 32 hex characters or canonical hyphenated UUID.
     #[arg(long, value_name = "UUID")]
@@ -264,6 +292,10 @@ pub enum CliError {
         "contact `{query}` is not in local storage; run `contact add --alias <ALIAS> --fingerprint <HEX>` first"
     )]
     MissingContact { query: String },
+    #[error("contact `{alias}` is not trusted; run `contact trust {alias}` after verifying the fingerprint")]
+    ContactNotTrusted { alias: String },
+    #[error("contact `{alias}` has no stored public key; run `onboard --alias {alias} ...` or `key-request --peer <ADDR>` first")]
+    ContactMissingPublicKey { alias: String },
     #[error(
         "contact alias `{alias}` is already pinned to fingerprint {existing_fingerprint}; refusing to replace it with {new_fingerprint}"
     )]
@@ -316,6 +348,10 @@ pub enum CliError {
     InvalidKeyServeDuration,
     #[error("receive duration must be greater than zero")]
     InvalidReceiveDuration,
+    #[error("chat duration must be greater than zero")]
+    InvalidChatDuration,
+    #[error("failed to read chat stdin: {0}")]
+    ReadStdin(#[source] io::Error),
     #[error("invalid message hash: {0}")]
     InvalidMessageHash(String),
     #[error("invalid conversation UUID: {0}")]
@@ -407,6 +443,10 @@ pub fn run<W: Write>(cli: Cli, mut writer: W) -> Result<(), CliError> {
         CliCommand::Send(args) => {
             let runtime = runtime()?;
             runtime.block_on(run_send(cli.config_path(), args, &mut writer))?;
+        }
+        CliCommand::Chat(args) => {
+            let runtime = runtime()?;
+            runtime.block_on(run_chat(cli.config_path(), args, &mut writer))?;
         }
         CliCommand::Conversations => run_conversations(cli.config_path(), &mut writer)?,
         CliCommand::History(args) => run_history(cli.config_path(), args, &mut writer)?,
@@ -743,6 +783,156 @@ async fn run_send<W: Write>(
     Ok(())
 }
 
+async fn run_chat<W: Write>(
+    config_path: PathBuf,
+    args: ChatArgs,
+    writer: &mut W,
+) -> Result<(), CliError> {
+    if args.duration_ms == 0 {
+        return Err(CliError::InvalidChatDuration);
+    }
+
+    let conversation_uuid = parse_uuid(&args.conversation)?;
+    let storage = open_storage(config_path)?;
+    let local = load_local_identity(&args.secret_key)?;
+    let contact = find_contact(&storage, &args.contact)?;
+    require_trusted_contact(&contact)?;
+    let peer = load_peer_identity_from_fingerprint(&storage, contact.fingerprint)?;
+    storage
+        .ensure_conversation(conversation_uuid)
+        .map_err(CliError::PersistMessage)?;
+
+    let mut history = chat_history(&storage, conversation_uuid)?;
+    writeln!(
+        writer,
+        "chat: conversation_uuid={} contact={} fingerprint={} messages={}",
+        uuid_hex(&conversation_uuid),
+        contact.alias,
+        fingerprint_hex(&contact.fingerprint),
+        history.len()
+    )?;
+    writeln!(
+        writer,
+        "message_uuid\tsender_fingerprint\ttimestamp\tdelivery_state\treply_state\tpayload"
+    )?;
+    for message in &history {
+        write_history_message(writer, message)?;
+    }
+
+    let mut latest_hash = history
+        .last()
+        .map(|message| message.message_hash)
+        .unwrap_or([0; 32]);
+    let mut service =
+        ChatMessageService::start(args.listen, local.clone(), peer.clone(), latest_hash).await?;
+    writeln!(
+        writer,
+        "chat: listening on {} for {} ms",
+        service.local_addr(),
+        args.duration_ms
+    )?;
+    writeln!(writer, "chat: enter one plaintext message per stdin line")?;
+
+    let deadline = tokio::time::sleep(Duration::from_millis(args.duration_ms));
+    pin!(deadline);
+    let stdin = BufReader::new(tokio::io::stdin());
+    let mut lines = stdin.lines();
+    let mut stdin_done = false;
+    let mut sent = 0_u64;
+    let mut received_count = 0_u64;
+
+    loop {
+        tokio::select! {
+            _ = &mut deadline => {
+                break;
+            }
+            maybe_line = lines.next_line(), if !stdin_done => {
+                let maybe_line = maybe_line.map_err(CliError::ReadStdin)?;
+                let Some(line) = maybe_line else {
+                    stdin_done = true;
+                    continue;
+                };
+                if line.is_empty() {
+                    continue;
+                }
+
+                let (message, ack) = message_transport::send_chat_message_and_record_ack(
+                    args.peer,
+                    &local,
+                    &peer,
+                    OutgoingChatMessage {
+                        conversation_uuid,
+                        previous_hash: latest_hash,
+                        headers: b"Content-Type: text/plain".to_vec(),
+                        plaintext: line.as_bytes().to_vec(),
+                    },
+                    &storage,
+                )
+                .await?;
+                storage
+                    .insert_accepted_chat_message(AcceptedChatMessageInsert {
+                        conversation_uuid: message.conv_uuid,
+                        message_uuid: message.uuid,
+                        previous_hash: message.prev_hash,
+                        message_hash: ack.message_hash,
+                        sender: message.source,
+                        sent_at: i64::from(message.timestamp),
+                        headers: message.headers,
+                        encrypted_payload: message.data,
+                        decrypted_payload: line.into_bytes(),
+                        reply_to: None,
+                    })
+                    .map_err(CliError::PersistMessage)?;
+                latest_hash = ack.message_hash;
+                sent += 1;
+                writeln!(
+                    writer,
+                    "chat: delivered message_uuid={} acked_by={}",
+                    uuid_hex(&ack.message_uuid),
+                    fingerprint_hex(&ack.acknowledger)
+                )?;
+            }
+            received = service.recv() => {
+                let Some(received) = received else {
+                    break;
+                };
+                storage
+                    .insert_accepted_chat_message(AcceptedChatMessageInsert {
+                        conversation_uuid: received.conversation_uuid,
+                        message_uuid: received.uuid,
+                        previous_hash: received.previous_hash,
+                        message_hash: received.message_hash,
+                        sender: received.source,
+                        sent_at: i64::from(received.timestamp),
+                        headers: received.headers,
+                        encrypted_payload: received.encrypted_payload,
+                        decrypted_payload: received.plaintext,
+                        reply_to: None,
+                    })
+                    .map_err(CliError::PersistMessage)?;
+                latest_hash = received.message_hash;
+                received_count += 1;
+                writeln!(
+                    writer,
+                    "chat: received message_uuid={} message_hash={}",
+                    uuid_hex(&received.uuid),
+                    fingerprint_hex(&received.message_hash)
+                )?;
+            }
+        }
+    }
+
+    history = chat_history(&storage, conversation_uuid)?;
+    writeln!(
+        writer,
+        "chat: stopped sent={} received={} messages={}",
+        sent,
+        received_count,
+        history.len()
+    )?;
+    Ok(())
+}
+
 fn run_conversations<W: Write>(config_path: PathBuf, writer: &mut W) -> Result<(), CliError> {
     let storage = open_storage(config_path)?;
     let engine = ConversationEngine::new(&storage);
@@ -900,6 +1090,30 @@ fn find_contact(storage: &Storage, query: &str) -> Result<ContactRecord, CliErro
         .ok_or_else(|| CliError::MissingContact {
             query: query.to_owned(),
         })
+}
+
+fn require_trusted_contact(contact: &ContactRecord) -> Result<(), CliError> {
+    if contact.trust_state != ContactTrustState::Trusted {
+        return Err(CliError::ContactNotTrusted {
+            alias: contact.alias.clone(),
+        });
+    }
+    if !contact.public_key_present {
+        return Err(CliError::ContactMissingPublicKey {
+            alias: contact.alias.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn chat_history(
+    storage: &Storage,
+    conversation_uuid: [u8; 16],
+) -> Result<Vec<ConversationMessage>, CliError> {
+    let engine = ConversationEngine::new(storage);
+    engine
+        .message_history(conversation_uuid)
+        .map_err(|error| conversation_error(error, conversation_uuid))
 }
 
 fn write_contact_header<W: Write>(writer: &mut W) -> Result<(), io::Error> {
@@ -1124,12 +1338,19 @@ fn load_peer_identity(
     fingerprint: &str,
 ) -> Result<PeerChatIdentity, CliError> {
     let parsed = parse_fingerprint(fingerprint)?;
+    load_peer_identity_from_fingerprint(storage, parsed)
+}
+
+fn load_peer_identity_from_fingerprint(
+    storage: &Storage,
+    fingerprint: Fingerprint,
+) -> Result<PeerChatIdentity, CliError> {
     let Some(record) = storage
-        .get_peer_key(parsed)
+        .get_peer_key(fingerprint)
         .map_err(CliError::PersistMessage)?
     else {
         return Err(CliError::MissingPeerKey {
-            fingerprint: fingerprint.to_owned(),
+            fingerprint: fingerprint_hex(&fingerprint),
         });
     };
     let public_key =
@@ -1293,6 +1514,7 @@ mod tests {
         assert!(help.contains("discover"));
         assert!(help.contains("receive"));
         assert!(help.contains("send"));
+        assert!(help.contains("chat"));
         assert!(help.contains("conversations"));
         assert!(help.contains("history"));
         assert!(help.contains("contact"));
@@ -1341,6 +1563,40 @@ mod tests {
                 previous_hash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                     .to_owned(),
                 message: "hello bob".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_chat_subcommand_with_bounded_options() {
+        let cli = Cli::parse_from([
+            "decentra-chat",
+            "--config",
+            "config.toml",
+            "chat",
+            "--secret-key",
+            "alice.secret",
+            "--contact",
+            "bob",
+            "--peer",
+            "127.0.0.1:52001",
+            "--listen",
+            "127.0.0.1:52002",
+            "--conversation",
+            "11111111-1111-4111-8111-111111111111",
+            "--duration-ms",
+            "250",
+        ]);
+
+        assert_eq!(
+            cli.command(),
+            CliCommand::Chat(ChatArgs {
+                secret_key: PathBuf::from("alice.secret"),
+                contact: "bob".to_owned(),
+                peer: "127.0.0.1:52001".parse().expect("socket addr"),
+                listen: "127.0.0.1:52002".parse().expect("socket addr"),
+                conversation: "11111111-1111-4111-8111-111111111111".to_owned(),
+                duration_ms: 250,
             })
         );
     }

--- a/src/message_transport.rs
+++ b/src/message_transport.rs
@@ -9,13 +9,14 @@ use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::{
     net::SocketAddr,
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
-    sync::mpsc,
+    sync::{mpsc, Mutex},
     task::{JoinHandle, JoinSet},
 };
 
@@ -166,8 +167,16 @@ impl ChatMessageService {
             .map_err(ChatTransportError::LocalAddr)?;
         let (accepted_tx, accepted_rx) = mpsc::channel(16);
 
+        let expected_previous_hash = Arc::new(Mutex::new(expected_previous_hash));
         let task = tokio::spawn(async move {
-            listener_loop(listener, local, peer, expected_previous_hash, accepted_tx).await;
+            listener_loop(
+                listener,
+                local,
+                peer,
+                expected_previous_hash,
+                accepted_tx,
+            )
+            .await;
         });
 
         Ok(Self {
@@ -317,7 +326,7 @@ async fn listener_loop(
     listener: TcpListener,
     local: LocalChatIdentity,
     peer: PeerChatIdentity,
-    expected_previous_hash: [u8; 32],
+    expected_previous_hash: Arc<Mutex<[u8; 32]>>,
     accepted_tx: mpsc::Sender<ReceivedChatMessage>,
 ) {
     let mut connections = JoinSet::new();
@@ -331,6 +340,7 @@ async fn listener_loop(
                 let local = local.clone();
                 let peer = peer.clone();
                 let accepted_tx = accepted_tx.clone();
+                let expected_previous_hash = Arc::clone(&expected_previous_hash);
                 connections.spawn(async move {
                     if let Ok(message) =
                         handle_connection(stream, &local, &peer, expected_previous_hash).await
@@ -348,7 +358,7 @@ async fn handle_connection(
     mut stream: TcpStream,
     local: &LocalChatIdentity,
     peer: &PeerChatIdentity,
-    expected_previous_hash: [u8; 32],
+    expected_previous_hash: Arc<Mutex<[u8; 32]>>,
 ) -> Result<ReceivedChatMessage, ChatTransportError> {
     let message = read_message(&mut stream).await?;
     let Message::ChatMessage(message) = message else {
@@ -357,7 +367,11 @@ async fn handle_connection(
         });
     };
 
-    let accepted = accept_chat_message(message, local, peer, expected_previous_hash)?;
+    let mut expected = expected_previous_hash.lock().await;
+    let accepted = accept_chat_message(message, local, peer, *expected)?;
+    *expected = accepted.message_hash;
+    drop(expected);
+
     let ack = build_message_ack(&accepted, local)?;
     write_message(&mut stream, Message::MessageAck(ack)).await?;
 

--- a/tests/cli_e2e.rs
+++ b/tests/cli_e2e.rs
@@ -1,5 +1,6 @@
 use std::{
     fs,
+    io::Write,
     net::TcpListener,
     path::{Path, PathBuf},
     process::{Child, Command, Output, Stdio},
@@ -455,6 +456,180 @@ fn key_exchange_send_ack_and_history_work_through_public_cli() {
     assert!(history_stdout.contains("\tnone\thello bob from the cli"), "{history_stdout}");
 }
 
+#[test]
+fn bounded_chat_session_sends_two_messages_and_records_acknowledged_history() {
+    let fixture = TestFixture::new("chat-session");
+    let alice_storage = fixture.path("alice.sqlite3");
+    let bob_storage = fixture.path("bob.sqlite3");
+    let alice_config =
+        fixture.write_config("alice.toml", fixture.unique_udp_port(), &alice_storage);
+    let bob_config = fixture.write_config("bob.toml", fixture.unique_udp_port(), &bob_storage);
+    let alice_secret = fixture.path("alice.secret");
+    let alice_public = fixture.path("alice.public");
+    let bob_secret = fixture.path("bob.secret");
+    let bob_public = fixture.path("bob.public");
+
+    let alice_keygen = fixture.cli(
+        [
+            "keygen",
+            "--secret-key",
+            path_arg(&alice_secret),
+            "--public-key",
+            path_arg(&alice_public),
+        ],
+        "alice keygen for chat session",
+    );
+    assert_success(&alice_keygen, "alice keygen for chat session");
+    let bob_keygen = fixture.cli(
+        [
+            "keygen",
+            "--secret-key",
+            path_arg(&bob_secret),
+            "--public-key",
+            path_arg(&bob_public),
+        ],
+        "bob keygen for chat session",
+    );
+    assert_success(&bob_keygen, "bob keygen for chat session");
+    let alice_fingerprint = fingerprint_from_keygen(&stdout(&alice_keygen));
+    let bob_fingerprint = fingerprint_from_keygen(&stdout(&bob_keygen));
+
+    let bob_key_addr = format!("127.0.0.1:{}", free_tcp_port());
+    let mut bob_key_server = fixture.spawn_cli(
+        [
+            "key-serve",
+            "--public-key",
+            path_arg(&bob_public),
+            "--listen",
+            bob_key_addr.as_str(),
+            "--duration-ms",
+            "10000",
+        ],
+        "bob key-serve for chat session",
+    );
+    let alice_request = fixture.eventually_cli(
+        [
+            "--config",
+            path_arg(&alice_config),
+            "onboard",
+            "--alias",
+            "bob",
+            "--fingerprint",
+            bob_fingerprint.as_str(),
+            "--peer",
+            bob_key_addr.as_str(),
+            "--trust",
+        ],
+        "alice onboard bob for chat session",
+    );
+    assert_success(&alice_request, "alice onboard bob for chat session");
+    bob_key_server.kill_and_wait();
+
+    let alice_key_addr = format!("127.0.0.1:{}", free_tcp_port());
+    let mut alice_key_server = fixture.spawn_cli(
+        [
+            "key-serve",
+            "--public-key",
+            path_arg(&alice_public),
+            "--listen",
+            alice_key_addr.as_str(),
+            "--duration-ms",
+            "10000",
+        ],
+        "alice key-serve for chat session",
+    );
+    let bob_request = fixture.eventually_cli(
+        [
+            "--config",
+            path_arg(&bob_config),
+            "onboard",
+            "--alias",
+            "alice",
+            "--fingerprint",
+            alice_fingerprint.as_str(),
+            "--peer",
+            alice_key_addr.as_str(),
+            "--trust",
+        ],
+        "bob onboard alice for chat session",
+    );
+    assert_success(&bob_request, "bob onboard alice for chat session");
+    alice_key_server.kill_and_wait();
+
+    let conversation = "11111111-1111-4111-8111-111111111111";
+    let alice_chat_addr = format!("127.0.0.1:{}", free_tcp_port());
+    let bob_chat_addr = format!("127.0.0.1:{}", free_tcp_port());
+    let mut bob_chat = fixture.spawn_cli_with_closed_stdin(
+        [
+            "--config",
+            path_arg(&bob_config),
+            "chat",
+            "--secret-key",
+            path_arg(&bob_secret),
+            "--contact",
+            "alice",
+            "--peer",
+            alice_chat_addr.as_str(),
+            "--listen",
+            bob_chat_addr.as_str(),
+            "--conversation",
+            conversation,
+            "--duration-ms",
+            "3000",
+        ],
+        "bob chat session",
+    );
+
+    let alice_chat = fixture.eventually_cli_with_stdin(
+        [
+            "--config",
+            path_arg(&alice_config),
+            "chat",
+            "--secret-key",
+            path_arg(&alice_secret),
+            "--contact",
+            "bob",
+            "--peer",
+            bob_chat_addr.as_str(),
+            "--listen",
+            alice_chat_addr.as_str(),
+            "--conversation",
+            conversation,
+            "--duration-ms",
+            "500",
+        ],
+        "first chat line\nsecond chat line\n",
+        "alice chat session",
+    );
+    assert_success(&alice_chat, "alice chat session");
+    let bob_output = bob_chat.wait_with_timeout(CLI_TIMEOUT);
+    assert_success(&bob_output, "bob chat session");
+
+    let alice_stdout = stdout(&alice_chat);
+    let bob_stdout = stdout(&bob_output);
+    assert!(alice_stdout.contains("chat: delivered"), "{alice_stdout}");
+    assert!(alice_stdout.contains("chat: stopped sent=2"), "{alice_stdout}");
+    assert!(bob_stdout.contains("chat: received"), "{bob_stdout}");
+    assert!(bob_stdout.contains("chat: stopped sent=0 received=2"), "{bob_stdout}");
+
+    let history = fixture.cli(
+        [
+            "--config",
+            path_arg(&alice_config),
+            "history",
+            "--conversation",
+            conversation,
+        ],
+        "alice chat session history",
+    );
+    assert_success(&history, "alice chat session history");
+    let history_stdout = stdout(&history);
+    assert!(history_stdout.contains("messages=2"), "{history_stdout}");
+    assert!(history_stdout.contains("acknowledged:"), "{history_stdout}");
+    assert!(history_stdout.contains("\tnone\tfirst chat line"), "{history_stdout}");
+    assert!(history_stdout.contains("\tnone\tsecond chat line"), "{history_stdout}");
+}
+
 struct TestFixture {
     root: tempfile::TempDir,
 }
@@ -519,6 +694,32 @@ storage_path = "{}"
         );
     }
 
+    fn eventually_cli_with_stdin<const N: usize>(
+        &self,
+        args: [&str; N],
+        stdin: &str,
+        description: &str,
+    ) -> Output {
+        let deadline = Instant::now() + BACKGROUND_READY_TIMEOUT;
+        let mut last_output = None;
+        while Instant::now() < deadline {
+            let output = run_cli_with_stdin(args, Some(stdin), CLI_TIMEOUT, description);
+            if output.status.success() {
+                return output;
+            }
+            last_output = Some(output);
+            thread::sleep(Duration::from_millis(100));
+        }
+
+        let output = last_output.expect("command was attempted at least once");
+        panic!(
+            "{description} did not succeed before timeout\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            stdout(&output),
+            stderr(&output)
+        );
+    }
+
     fn spawn_cli<const N: usize>(
         &self,
         args: [&str; N],
@@ -531,6 +732,27 @@ storage_path = "{}"
             .stderr(Stdio::piped())
             .spawn()
             .expect("spawn CLI process");
+        ChildGuard {
+            child: Some(child),
+            description,
+            args: args.map(str::to_owned).to_vec(),
+        }
+    }
+
+    fn spawn_cli_with_closed_stdin<const N: usize>(
+        &self,
+        args: [&str; N],
+        description: &'static str,
+    ) -> ChildGuard {
+        let mut child = Command::new(cli_bin())
+            .args(args)
+            .current_dir(self.root.path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn CLI process");
+        drop(child.stdin.take());
         ChildGuard {
             child: Some(child),
             description,
@@ -592,12 +814,28 @@ impl Drop for ChildGuard {
 }
 
 fn run_cli<const N: usize>(args: [&str; N], timeout: Duration, description: &str) -> Output {
+    run_cli_with_stdin(args, None, timeout, description)
+}
+
+fn run_cli_with_stdin<const N: usize>(
+    args: [&str; N],
+    stdin: Option<&str>,
+    timeout: Duration,
+    description: &str,
+) -> Output {
     let mut child = Command::new(cli_bin())
         .args(args)
+        .stdin(stdin.map_or(Stdio::null(), |_| Stdio::piped()))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn CLI command");
+    if let Some(input) = stdin {
+        let mut child_stdin = child.stdin.take().expect("stdin is piped");
+        child_stdin
+            .write_all(input.as_bytes())
+            .expect("write CLI stdin");
+    }
     let deadline = Instant::now() + timeout;
 
     loop {


### PR DESCRIPTION
## Summary
- add a bounded `chat` CLI command for trusted contacts that prints startup history, sends each stdin line over encrypted TCP, records ACKs, and polls for inbound messages until the deadline
- allow the chat receiver to advance expected `prev_hash` across multiple accepted messages
- document the bounded chat workflow and add black-box two-node loopback coverage with two acknowledged messages

Closes #54

## Verification
- `git diff --check`
- `RUST_MIN_STACK=16777216 cargo test --test cli_e2e bounded_chat_session_sends_two_messages_and_records_acknowledged_history`
- `RUST_MIN_STACK=16777216 cargo test`

`cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` are unavailable in this runner because cargo reports no such subcommand.