### PR TITLE
docs: update CLI guide for contact-first chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Use `--config` when you want an isolated node profile:
 cargo run -- --config ./config.toml status
 ```
 
-For a complete loopback walkthrough with two local identities, key exchange,
-message send/receive, bounded chat sessions, delivery state, and conversation history, follow the
-[CLI user guide](docs/CLI_GUIDE.md).
+For a complete loopback walkthrough with two local identities, trusted contacts,
+peer onboarding, bounded chat sessions, delivery state, and conversation
+history, follow the [CLI user guide](docs/CLI_GUIDE.md).
 
 Show the command surface at any time:
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -2,8 +2,14 @@
 
 The DecentraChat CLI is the current user-facing client. It can inspect local
 configuration, initialize storage, manage local contacts, run bounded LAN
-discovery, exchange public keys, send and receive encrypted messages, run a
-bounded stdin-driven chat session, and read conversation history from SQLite.
+discovery, onboard discovered peers, exchange public keys, send and receive
+encrypted messages, run a bounded stdin-driven chat session, and read
+conversation history from SQLite.
+
+The preferred path is contact-first: create a local identity, onboard a peer
+into the contact book, trust the pinned fingerprint, then use `chat`. The lower
+level `key-request`, `send`, and `receive` commands are still useful for testing
+and debugging one part of the stack at a time.
 
 The commands below describe what is implemented in `src/cli.rs` today. There is
 no TUI or long-running chat daemon yet.
@@ -64,37 +70,18 @@ EOF
 cargo run -- --config ./decentra-chat.toml status
 ```
 
-## Local Peer Discovery
+## First Local Chat
 
-Discovery is bounded. The command announces the local node for a fixed duration,
-prints progress once per second, then prints the peer table visible from the
-local registry.
-
-```sh
-cargo run -- --config ./decentra-chat.toml discover \
-  --nick local \
-  --fingerprint 0000000000000000000000000000000000000000000000000000000000000000 \
-  --listen-port 51001 \
-  --multicast-interface 127.0.0.1 \
-  --duration-ms 3000 \
-  --announce-interval-ms 1000
-```
-
-Use a real key fingerprint after generating an identity. The all-zero
-fingerprint is only useful for checking that the discovery command starts and
-prints the expected table.
-
-## Loopback Chat Quickstart
-
-This script creates two local node profiles, exchanges public keys over the TCP
-key-exchange command, sends one encrypted signed message from Alice to Bob, then
-prints the conversation list and history from Alice's storage.
+This loopback script creates two isolated node profiles, generates two PGP
+identities, onboards each peer as a trusted contact, sends two chat lines from
+Alice to Bob, then prints Alice's conversation history.
 
 ```sh
 set -eu
 
 REPO_DIR="$(pwd)"
-DEMO_DIR="$(mktemp -d)"
+DEMO_DIR="$REPO_DIR/target/cli-guide-demo-$$"
+mkdir -p "$DEMO_DIR"
 cd "$DEMO_DIR"
 
 cat > alice.toml <<'EOF'
@@ -127,7 +114,11 @@ cargo run --manifest-path "$REPO_DIR/Cargo.toml" -- \
 BOB_KEY_SERVE_PID="$!"
 sleep 1
 cargo run --manifest-path "$REPO_DIR/Cargo.toml" -- \
-  --config ./alice.toml key-request --peer 127.0.0.1:52002
+  --config ./alice.toml onboard \
+  --alias bob \
+  --fingerprint "$BOB_FINGERPRINT" \
+  --peer 127.0.0.1:52002 \
+  --trust
 kill "$BOB_KEY_SERVE_PID" 2>/dev/null || true
 wait "$BOB_KEY_SERVE_PID" 2>/dev/null || true
 
@@ -137,32 +128,39 @@ cargo run --manifest-path "$REPO_DIR/Cargo.toml" -- \
 ALICE_KEY_SERVE_PID="$!"
 sleep 1
 cargo run --manifest-path "$REPO_DIR/Cargo.toml" -- \
-  --config ./bob.toml key-request --peer 127.0.0.1:52002
+  --config ./bob.toml onboard \
+  --alias alice \
+  --fingerprint "$ALICE_FINGERPRINT" \
+  --peer 127.0.0.1:52002 \
+  --trust
 kill "$ALICE_KEY_SERVE_PID" 2>/dev/null || true
 wait "$ALICE_KEY_SERVE_PID" 2>/dev/null || true
 
 CONVERSATION_ID="11111111-1111-4111-8111-111111111111"
 
-cargo run --manifest-path "$REPO_DIR/Cargo.toml" -- \
-  --config ./bob.toml receive \
+printf '' | cargo run --manifest-path "$REPO_DIR/Cargo.toml" -- \
+  --config ./bob.toml chat \
   --secret-key ./bob.secret \
-  --peer-fingerprint "$ALICE_FINGERPRINT" \
-  --listen 127.0.0.1:52003 \
-  --duration-ms 30000 \
-  > bob-receive.log 2>&1 &
-BOB_RECEIVE_PID="$!"
+  --contact alice \
+  --peer 127.0.0.1:52003 \
+  --listen 127.0.0.1:52004 \
+  --conversation "$CONVERSATION_ID" \
+  --duration-ms 3000 \
+  > bob-chat.log 2>&1 &
+BOB_CHAT_PID="$!"
 sleep 1
 
-cargo run --manifest-path "$REPO_DIR/Cargo.toml" -- \
-  --config ./alice.toml send \
+printf 'first message\nsecond message\n' | cargo run --manifest-path "$REPO_DIR/Cargo.toml" -- \
+  --config ./alice.toml chat \
   --secret-key ./alice.secret \
-  --peer-fingerprint "$BOB_FINGERPRINT" \
-  --peer 127.0.0.1:52003 \
+  --contact bob \
+  --peer 127.0.0.1:52004 \
+  --listen 127.0.0.1:52003 \
   --conversation "$CONVERSATION_ID" \
-  "hello bob"
+  --duration-ms 500
 
-wait "$BOB_RECEIVE_PID"
-cat bob-receive.log
+wait "$BOB_CHAT_PID"
+cat bob-chat.log
 
 cargo run --manifest-path "$REPO_DIR/Cargo.toml" -- \
   --config ./alice.toml conversations
@@ -171,43 +169,16 @@ cargo run --manifest-path "$REPO_DIR/Cargo.toml" -- \
 ```
 
 Run the script from the repository root. It stores demo keys, config files, and
-SQLite databases in a temporary directory.
+SQLite databases in a temporary directory. The `chat` sessions are bounded, so
+they exit after `--duration-ms` even when no more messages arrive.
 
-## Key Exchange
-
-Generate a local PGP identity:
-
-```sh
-cargo run -- keygen --secret-key ./alice.secret --public-key ./alice.public
-```
-
-The command writes both key files and prints the DecentraChat fingerprint. The
-secret key is used for signing and decrypting local messages. The public key is
-served to peers.
-
-Serve a public key for a bounded window:
-
-```sh
-cargo run -- key-serve --public-key ./alice.public --listen 127.0.0.1:52002 --duration-ms 30000
-```
-
-Request a peer public key and persist it in the configured SQLite store:
-
-```sh
-cargo run -- --config ./bob.toml key-request --peer 127.0.0.1:52002
-```
-
-`send` and `receive` require the peer fingerprint to exist in local storage.
-When it is missing, the CLI exits with an error that points back to
-`key-request`.
-
-## Onboarding a Discovered Peer
+## Onboard a Peer
 
 `onboard` is the shortest path from a discovery row to a trusted local contact.
 Pass the advertised peer address, advertised fingerprint, and the alias you want
-to use locally. The command runs the same TCP key-exchange protocol as
-`key-request`, verifies that the fetched public key matches the advertised
-fingerprint, stores the peer key, and creates or updates the contact record.
+to use locally. The command runs the TCP key-exchange protocol, verifies that
+the fetched public key matches the advertised fingerprint, stores the peer key,
+and creates or updates the contact record.
 
 ```sh
 cargo run -- --config ./alice.toml onboard \
@@ -217,20 +188,25 @@ cargo run -- --config ./alice.toml onboard \
   --trust
 ```
 
-`--trust` is the explicit non-interactive trust decision. Omit it to fetch and
-store the key as an untrusted contact, then run `contact trust bob` after
-verifying the fingerprint out of band.
+`--trust` is the explicit non-interactive trust decision. Use it only after you
+have verified the fingerprint through discovery or another channel. Omit it to
+fetch and store the key as an untrusted contact, then run `contact trust bob`
+after verifying the fingerprint out of band.
 
 If an alias already belongs to a different fingerprint, onboarding fails before
-requesting a new key. This prevents a discovered fingerprint change from
-silently replacing an existing pin.
+requesting a new key. That refusal is the fingerprint-change warning: the CLI
+will not silently replace a pinned alias with a different peer identity.
+
+If the peer returns a public key with a different fingerprint than the one you
+passed, onboarding fails and prints both fingerprints. Re-run discovery or
+verify the peer manually before trusting the new value.
 
 ## Contact Book and Trust
 
 Contacts are local aliases pinned to peer fingerprints in the configured SQLite
 store. `chat` requires a trusted contact with a stored public key. The lower
-level `key-request`, `send`, `receive`, `conversations`, and `history`
-commands still accept the same fingerprint arguments as before.
+level `key-request`, `send`, `receive`, `conversations`, and `history` commands
+still accept the same fingerprint arguments as before.
 
 Add or update an alias for a fingerprint:
 
@@ -270,7 +246,80 @@ aliases, aliases with leading or trailing spaces, control characters, tabs, or
 newlines, and aliases longer than 64 bytes. Reusing an alias for a different
 fingerprint fails with an actionable conflict error.
 
-## Sending and Receiving
+## Bounded Chat Session
+
+`chat` opens one conversation with one trusted contact. It prints the current
+conversation history, listens for inbound messages until `--duration-ms`
+expires, and sends each non-empty stdin line through the same encrypted TCP path
+used by `send`. Sent messages are persisted with their ACK state, and received
+messages are persisted for later history reads.
+
+```sh
+printf 'first message\nsecond message\n' | cargo run -- --config ./alice.toml chat \
+  --secret-key ./alice.secret \
+  --contact bob \
+  --peer 127.0.0.1:52003 \
+  --listen 127.0.0.1:52004 \
+  --conversation 11111111-1111-4111-8111-111111111111 \
+  --duration-ms 30000
+```
+
+Start the peer's `chat` command first with the opposite `--peer` and `--listen`
+addresses. Close stdin on a receive-only session; it will continue polling
+inbound messages until the bounded duration expires.
+
+`chat` refuses untrusted contacts and contacts without stored public keys. Use
+`onboard --trust` for the usual setup, or combine `key-request`, `contact add`,
+and `contact trust` when you need to test each step separately.
+
+## Local Peer Discovery
+
+Discovery is bounded. The command announces the local node for a fixed duration,
+prints progress once per second, then prints the peer table visible from the
+local registry.
+
+```sh
+cargo run -- --config ./decentra-chat.toml discover \
+  --nick local \
+  --fingerprint "$ALICE_FINGERPRINT" \
+  --listen-port 51001 \
+  --multicast-interface 127.0.0.1 \
+  --duration-ms 3000 \
+  --announce-interval-ms 1000
+```
+
+Use the fingerprint printed by `keygen`. The advertised `--listen-port` should
+be the TCP port where the peer can serve follow-up commands such as
+`key-serve`.
+
+## Key Exchange Reference
+
+Generate a local PGP identity:
+
+```sh
+cargo run -- keygen --secret-key ./alice.secret --public-key ./alice.public
+```
+
+The command writes both key files and prints the DecentraChat fingerprint. The
+secret key is used for signing and decrypting local messages. The public key is
+served to peers.
+
+Serve a public key for a bounded window:
+
+```sh
+cargo run -- key-serve --public-key ./alice.public --listen 127.0.0.1:52002 --duration-ms 30000
+```
+
+Request a peer public key and persist it in the configured SQLite store:
+
+```sh
+cargo run -- --config ./bob.toml key-request --peer 127.0.0.1:52002
+```
+
+`key-request` only stores the peer key. It does not create an alias or mark the
+peer trusted; use `onboard` for the usual user-facing path.
+
+## One-Message Send and Receive
 
 `receive` waits for one encrypted signed message from a known peer, persists the
 accepted message, then exits:
@@ -298,28 +347,6 @@ cargo run -- --config ./alice.toml send \
 When `--conversation` is omitted, `send` creates a new UUID v4. Use
 `--previous-hash` when appending to an existing message chain. The default
 previous hash is the zero hash, which starts a chain segment.
-
-## Bounded Chat Session
-
-`chat` opens one conversation with one trusted contact. It prints the current
-conversation history, listens for inbound messages until `--duration-ms`
-expires, and sends each non-empty stdin line through the same encrypted TCP path
-used by `send`. Sent messages are persisted with their ACK state, and received
-messages are persisted for later history reads.
-
-```sh
-printf 'first message\nsecond message\n' | cargo run -- --config ./alice.toml chat \
-  --secret-key ./alice.secret \
-  --contact bob \
-  --peer 127.0.0.1:52003 \
-  --listen 127.0.0.1:52004 \
-  --conversation 11111111-1111-4111-8111-111111111111 \
-  --duration-ms 30000
-```
-
-For loopback testing, start the peer's `chat` command first with the opposite
-`--peer` and `--listen` addresses. Close stdin on a receive-only session; it
-will continue polling inbound messages until the bounded duration expires.
 
 ## Delivery State and History
 
@@ -363,10 +390,34 @@ Check that the parent directory is writable. `status` opens storage and applies
 migrations, so it is the quickest way to verify a profile before running network
 commands.
 
+`error: contact 'bob' is not trusted`
+
+Run `contact show bob` and verify the fingerprint. If it is the peer you expect,
+run `contact trust bob`. For the normal setup flow, use `onboard --trust` after
+verifying the advertised fingerprint.
+
+`error: contact 'bob' has no stored public key`
+
+Run `onboard --alias bob --fingerprint <HEX> --peer <ADDR> --trust` while the
+peer is serving its public key, or run `key-request --peer <ADDR>` against the
+peer's `key-serve` command when testing the lower-level flow.
+
+`error: contact alias 'bob' is already pinned to fingerprint ...`
+
+The alias already points at a different fingerprint. Do not overwrite it until
+you have verified whether the peer re-keyed, you selected the wrong alias, or a
+different node is advertising the same name.
+
+`error: peer at ... returned fingerprint ..., but discovery advertised ...`
+
+The key served over TCP does not match the fingerprint you passed to `onboard`.
+Re-run discovery or verify the peer through another channel before trusting it.
+
 `error: peer key ... is not in storage`
 
 Run `key-request --peer <ADDR>` against the peer's `key-serve` command, using
-the same `--config` file you will use for `send` or `receive`.
+the same `--config` file you will use for `send` or `receive`. The contact-first
+alternative is `onboard`, which stores the key and creates the alias together.
 
 `error: receive timed out after ... ms without an accepted message`
 


### PR DESCRIPTION
## Summary
- reorganize the CLI guide around the preferred identity, onboarding, trusted contact, and bounded chat workflow
- update the loopback walkthrough to use onboard and chat before the lower-level send/receive reference
- add user-facing troubleshooting for trust, missing public keys, alias conflicts, and fingerprint mismatches
- refresh the README quickstart pointer to match the contact-first path

Closes #55

## Verification
- RUST_MIN_STACK=16777216 cargo run -- --help
- RUST_MIN_STACK=16777216 cargo test
- RUST_MIN_STACK=16777216 sed -n '80,168p' docs/CLI_GUIDE.md | RUST_MIN_STACK=16777216 bash