### PR TITLE
Centralize protocol message names

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -84,6 +84,19 @@ pub enum Message {
     MessageAck(MessageAck),
 }
 
+impl Message {
+    /// Returns the stable user-facing name for this protocol message variant.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::DiscoveryAnnounce(_) => "discovery announce",
+            Self::KeyExchangeReq(_) => "key-exchange request",
+            Self::KeyExchangeResp(_) => "key-exchange response",
+            Self::ChatMessage(_) => "chat message",
+            Self::MessageAck(_) => "message ack",
+        }
+    }
+}
+
 impl TryFrom<&[u8]> for DiscoveryAnnounce {
     type Error = CodecError;
 
@@ -374,6 +387,63 @@ mod tests {
 
     fn bytes_32(seed: u8) -> [u8; 32] {
         [seed; 32]
+    }
+
+    #[test]
+    fn message_names_are_stable() {
+        let cases = [
+            (
+                Message::DiscoveryAnnounce(DiscoveryAnnounce {
+                    version: 0,
+                    address: [0; 4],
+                    port: 0,
+                    nick: Vec::new(),
+                    key_fingerprint: [0; 32],
+                }),
+                "discovery announce",
+            ),
+            (
+                Message::KeyExchangeReq(KeyExchangeReq { version: 0 }),
+                "key-exchange request",
+            ),
+            (
+                Message::KeyExchangeResp(KeyExchangeResp {
+                    version: 0,
+                    key_data: Vec::new(),
+                }),
+                "key-exchange response",
+            ),
+            (
+                Message::ChatMessage(ChatMessage {
+                    version: 0,
+                    uuid: [0; 16],
+                    conv_uuid: [0; 16],
+                    conv_type: 0,
+                    prev_hash: [0; 32],
+                    timestamp: 0,
+                    source: [0; 32],
+                    destination: [0; 32],
+                    headers: Vec::new(),
+                    data: Vec::new(),
+                    signature: Vec::new(),
+                }),
+                "chat message",
+            ),
+            (
+                Message::MessageAck(MessageAck {
+                    version: 0,
+                    uuid: [0; 16],
+                    message_hash: [0; 32],
+                    acknowledger: [0; 32],
+                    signature: Vec::new(),
+                }),
+                "message ack",
+            ),
+        ];
+
+        for (message, expected_name) in cases {
+            assert_eq!(message.name(), expected_name);
+        }
     }
 
     #[test]

--- a/src/key_exchange.rs
+++ b/src/key_exchange.rs
@@ -142,7 +142,7 @@ pub async fn request_peer_key(
     let response = read_message(&mut stream).await?;
     let Message::KeyExchangeResp(response) = response else {
         return Err(KeyExchangeError::UnexpectedResponse {
-            received: message_name(&response),
+            received: response.name(),
         });
     };
 
@@ -175,7 +175,7 @@ async fn handle_connection(
     let request = read_message(&mut stream).await?;
     let Message::KeyExchangeReq(_request) = request else {
         return Err(KeyExchangeError::UnexpectedRequest {
-            received: message_name(&request),
+            received: request.name(),
         });
     };
 
@@ -267,16 +267,6 @@ async fn write_message(stream: &mut TcpStream, message: Message) -> Result<(), K
         operation: "flushing frame",
         source,
     })
-}
-
-fn message_name(message: &Message) -> &'static str {
-    match message {
-        Message::DiscoveryAnnounce(_) => "discovery announce",
-        Message::KeyExchangeReq(_) => "key-exchange request",
-        Message::KeyExchangeResp(_) => "key-exchange response",
-        Message::ChatMessage(_) => "chat message",
-        Message::MessageAck(_) => "message ack",
-    }
 }
 
 fn unix_timestamp() -> Result<i64, KeyExchangeError> {

--- a/src/message_transport.rs
+++ b/src/message_transport.rs
@@ -363,7 +363,7 @@ async fn handle_connection(
     let message = read_message(&mut stream).await?;
     let Message::ChatMessage(message) = message else {
         return Err(ChatTransportError::UnexpectedMessage {
-            received: message_name(&message),
+            received: message.name(),
         });
     };
 
@@ -462,7 +462,7 @@ async fn read_message_ack(
     let message = read_message(stream).await?;
     let Message::MessageAck(ack) = message else {
         return Err(ChatTransportError::UnexpectedMessage {
-            received: message_name(&message),
+            received: message.name(),
         });
     };
 
@@ -613,16 +613,6 @@ fn unix_timestamp() -> Result<i64, ChatTransportError> {
         .duration_since(UNIX_EPOCH)
         .map_err(|_| ChatTransportError::InvalidSystemTime)?;
     i64::try_from(duration.as_secs()).map_err(|_| ChatTransportError::InvalidSystemTime)
-}
-
-fn message_name(message: &Message) -> &'static str {
-    match message {
-        Message::DiscoveryAnnounce(_) => "discovery announce",
-        Message::KeyExchangeReq(_) => "key-exchange request",
-        Message::KeyExchangeResp(_) => "key-exchange response",
-        Message::ChatMessage(_) => "chat message",
-        Message::MessageAck(_) => "message ack",
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #60

## Summary
- add `Message::name()` as the single protocol variant name mapping
- update key exchange and chat transport unexpected-message errors to use the centralized mapping
- add codec coverage for the stable user-facing names

## Verification
- `RUST_MIN_STACK=16777216 cargo test`
- `git diff --check`

## Tooling unavailable
- `cargo fmt` failed because the `fmt` subcommand is not installed
- `rustfmt` failed because the binary is not installed
- `cargo clippy --all-targets --all-features -- -D warnings` failed because the `clippy` subcommand is not installed