### PR TITLE
refactor: centralize Unix timestamp conversion

### DIFF
--- a/src/key_exchange.rs
+++ b/src/key_exchange.rs
@@ -3,11 +3,9 @@ use crate::{
     crypto,
     discovery::Fingerprint,
     storage::{PeerKeyRecord, PeerKeyUpsert, Storage, StorageError},
+    time,
 };
-use std::{
-    net::SocketAddr,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::net::SocketAddr;
 use thiserror::Error;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -270,10 +268,7 @@ async fn write_message(stream: &mut TcpStream, message: Message) -> Result<(), K
 }
 
 fn unix_timestamp() -> Result<i64, KeyExchangeError> {
-    let duration = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|_| KeyExchangeError::InvalidSystemTime)?;
-    i64::try_from(duration.as_secs()).map_err(|_| KeyExchangeError::InvalidSystemTime)
+    time::unix_timestamp_secs().map_err(|_| KeyExchangeError::InvalidSystemTime)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,4 @@ pub mod discovery;
 pub mod key_exchange;
 pub mod message_transport;
 pub mod storage;
+mod time;

--- a/src/message_transport.rs
+++ b/src/message_transport.rs
@@ -3,15 +3,12 @@ use crate::{
     crypto,
     discovery::Fingerprint,
     storage::{MessageAckUpsert, Storage, StorageError},
+    time,
 };
 use pgp::composed::{SignedPublicKey, SignedSecretKey};
 use rand::RngCore;
 use sha2::{Digest, Sha256};
-use std::{
-    net::SocketAddr,
-    sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{net::SocketAddr, sync::Arc};
 use thiserror::Error;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -609,10 +606,7 @@ fn unix_timestamp_u32() -> Result<u32, ChatTransportError> {
 }
 
 fn unix_timestamp() -> Result<i64, ChatTransportError> {
-    let duration = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|_| ChatTransportError::InvalidSystemTime)?;
-    i64::try_from(duration.as_secs()).map_err(|_| ChatTransportError::InvalidSystemTime)
+    time::unix_timestamp_secs().map_err(|_| ChatTransportError::InvalidSystemTime)
 }
 
 #[cfg(test)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,10 +1,9 @@
-use crate::discovery::Fingerprint;
+use crate::{discovery::Fingerprint, time};
 use rusqlite::{params, Connection, OptionalExtension};
 use std::{
     collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
 
@@ -1135,10 +1134,7 @@ fn vec_to_fingerprint(bytes: Vec<u8>) -> Result<Fingerprint, StorageError> {
 }
 
 fn unix_timestamp() -> Result<i64, StorageError> {
-    let duration = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|_| StorageError::InvalidSystemTime)?;
-    i64::try_from(duration.as_secs()).map_err(|_| StorageError::InvalidSystemTime)
+    time::unix_timestamp_secs().map_err(|_| StorageError::InvalidSystemTime)
 }
 
 fn fingerprint_hex(fingerprint: &Fingerprint) -> String {

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,61 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+
+/// Errors returned while converting system time into Unix timestamp seconds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub(crate) enum UnixTimestampError {
+    #[error("system clock is before the Unix epoch")]
+    BeforeUnixEpoch,
+    #[error("Unix timestamp exceeds i64 range")]
+    Overflow,
+}
+
+/// Return the current Unix timestamp in whole seconds.
+pub(crate) fn unix_timestamp_secs() -> Result<i64, UnixTimestampError> {
+    unix_timestamp_secs_at(SystemTime::now())
+}
+
+fn unix_timestamp_secs_at(time: SystemTime) -> Result<i64, UnixTimestampError> {
+    let duration = time
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| UnixTimestampError::BeforeUnixEpoch)?;
+    duration_to_i64_secs(duration)
+}
+
+fn duration_to_i64_secs(duration: Duration) -> Result<i64, UnixTimestampError> {
+    i64::try_from(duration.as_secs()).map_err(|_| UnixTimestampError::Overflow)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unix_timestamp_secs_at_epoch_is_zero() {
+        assert_eq!(unix_timestamp_secs_at(UNIX_EPOCH), Ok(0));
+    }
+
+    #[test]
+    fn unix_timestamp_secs_at_counts_whole_seconds_after_epoch() {
+        assert_eq!(
+            unix_timestamp_secs_at(UNIX_EPOCH + Duration::from_secs(42)),
+            Ok(42)
+        );
+    }
+
+    #[test]
+    fn unix_timestamp_secs_at_rejects_times_before_epoch() {
+        assert_eq!(
+            unix_timestamp_secs_at(UNIX_EPOCH - Duration::from_secs(1)),
+            Err(UnixTimestampError::BeforeUnixEpoch)
+        );
+    }
+
+    #[test]
+    fn duration_to_i64_secs_rejects_overflow() {
+        assert_eq!(
+            duration_to_i64_secs(Duration::from_secs(i64::MAX as u64 + 1)),
+            Err(UnixTimestampError::Overflow)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a crate-private Unix timestamp helper with neutral pre-epoch and overflow errors
- route key exchange, chat transport, and storage timestamp helpers through the shared conversion
- cover epoch, after-epoch, pre-epoch, and overflow conversion behavior in focused unit tests

## Verification
- git diff --check
- RUST_MIN_STACK=16777216 cargo test

Note: cargo fmt and cargo clippy are unavailable in this checkout.

Closes #68