### PR TITLE
refactor: centralize UUID v4 helpers

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -3,9 +3,8 @@ use super::{
     output::{write_contact, write_contact_header, write_history_message, write_peer_list},
     parse::{
         fingerprint_hex, hex_value, load_local_identity, load_peer_identity,
-        load_peer_identity_from_fingerprint, new_uuid_v4, open_storage, parse_fingerprint,
-        parse_hash, parse_uuid, read_file, require_ipv4, uuid_hex, validate_cli_contact_alias,
-        write_file,
+        load_peer_identity_from_fingerprint, open_storage, parse_fingerprint, parse_hash,
+        parse_uuid, read_file, require_ipv4, uuid_hex, validate_cli_contact_alias, write_file,
     },
     CliError,
 };
@@ -17,6 +16,7 @@ use crate::{
     key_exchange::{self, KeyExchangeService, LocalKeyMaterial},
     message_transport::{self, ChatMessageService, OutgoingChatMessage},
     storage::{AcceptedChatMessageInsert, ContactRecord, ContactTrustState, ContactUpsert, Storage},
+    uuid::new_uuid_v4,
 };
 use std::{
     io::Write,

--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -5,9 +5,9 @@ use crate::{
     discovery::Fingerprint,
     message_transport::{LocalChatIdentity, PeerChatIdentity},
     storage::Storage,
+    uuid,
 };
 use pgp::composed::SignedSecretKey;
-use rand::RngCore;
 use std::{
     fs,
     io::Write,
@@ -68,7 +68,7 @@ pub(super) fn parse_uuid(input: &str) -> Result<[u8; 16], CliError> {
     }
 
     let uuid = parse_fixed_hex::<16>(&hex).map_err(CliError::InvalidConversationUuid)?;
-    if !is_uuid_v4(&uuid) {
+    if !uuid::is_uuid_v4(&uuid) {
         return Err(CliError::InvalidConversationUuid(
             "expected a non-zero UUID v4".to_owned(),
         ));
@@ -167,20 +167,6 @@ pub(super) fn write_file(path: &PathBuf, bytes: &[u8]) -> Result<(), CliError> {
         path: path.clone(),
         source,
     })
-}
-
-pub(super) fn new_uuid_v4() -> [u8; 16] {
-    let mut bytes = [0_u8; 16];
-    rand::thread_rng().fill_bytes(&mut bytes);
-    bytes[6] = (bytes[6] & 0x0f) | 0x40;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    bytes
-}
-
-fn is_uuid_v4(bytes: &[u8; 16]) -> bool {
-    bytes.iter().any(|byte| *byte != 0)
-        && bytes[6] & 0xf0 == 0x40
-        && bytes[8] & 0xc0 == 0x80
 }
 
 pub(super) fn hex_value(byte: u8) -> Option<u8> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod key_exchange;
 pub mod message_transport;
 pub mod storage;
 mod time;
+mod uuid;

--- a/src/message_transport.rs
+++ b/src/message_transport.rs
@@ -4,9 +4,9 @@ use crate::{
     discovery::Fingerprint,
     storage::{MessageAckUpsert, Storage, StorageError},
     time,
+    uuid,
 };
 use pgp::composed::{SignedPublicKey, SignedSecretKey};
-use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::{net::SocketAddr, sync::Arc};
 use thiserror::Error;
@@ -288,7 +288,7 @@ fn build_chat_message(
     peer: &PeerChatIdentity,
     outgoing: OutgoingChatMessage,
 ) -> Result<ChatMessage, ChatTransportError> {
-    if !is_uuid_v4(&outgoing.conversation_uuid) {
+    if !uuid::is_uuid_v4(&outgoing.conversation_uuid) {
         return Err(ChatTransportError::InvalidConversationUuid);
     }
     if outgoing.headers.len() > u16::MAX as usize {
@@ -301,7 +301,7 @@ fn build_chat_message(
         .map_err(ChatTransportError::Encrypt)?;
     let mut message = ChatMessage {
         version: WIRE_CHAT_VERSION,
-        uuid: new_uuid_v4(),
+        uuid: uuid::new_uuid_v4(),
         conv_uuid: outgoing.conversation_uuid,
         conv_type: CONVERSATION_TYPE_DIRECT,
         prev_hash: outgoing.previous_hash,
@@ -391,10 +391,10 @@ fn validate_chat_message(
             conv_type: message.conv_type,
         });
     }
-    if !is_uuid_v4(&message.uuid) {
+    if !uuid::is_uuid_v4(&message.uuid) {
         return Err(ChatTransportError::InvalidMessageUuid);
     }
-    if !is_uuid_v4(&message.conv_uuid) {
+    if !uuid::is_uuid_v4(&message.conv_uuid) {
         return Err(ChatTransportError::InvalidConversationUuid);
     }
     if message.prev_hash != expected_previous_hash {
@@ -579,20 +579,6 @@ async fn write_message(
         operation: "flushing frame",
         source,
     })
-}
-
-fn new_uuid_v4() -> [u8; 16] {
-    let mut bytes = [0_u8; 16];
-    rand::thread_rng().fill_bytes(&mut bytes);
-    bytes[6] = (bytes[6] & 0x0f) | 0x40;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    bytes
-}
-
-fn is_uuid_v4(bytes: &[u8; 16]) -> bool {
-    bytes.iter().any(|byte| *byte != 0)
-        && bytes[6] & 0xf0 == 0x40
-        && bytes[8] & 0xc0 == 0x80
 }
 
 fn timestamp_in_window(timestamp: u32) -> Result<bool, ChatTransportError> {

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -1,0 +1,45 @@
+use rand::RngCore;
+
+/// Generate a random non-zero UUID v4 byte array.
+pub(crate) fn new_uuid_v4() -> [u8; 16] {
+    let mut bytes = [0_u8; 16];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    bytes
+}
+
+/// Return whether the byte array is a non-zero RFC 4122 UUID v4 value.
+pub(crate) fn is_uuid_v4(bytes: &[u8; 16]) -> bool {
+    bytes.iter().any(|byte| *byte != 0)
+        && bytes[6] & 0xf0 == 0x40
+        && bytes[8] & 0xc0 == 0x80
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_uuid_sets_version_and_variant_bits() {
+        let uuid = new_uuid_v4();
+
+        assert!(is_uuid_v4(&uuid));
+        assert_eq!(uuid[6] & 0xf0, 0x40);
+        assert_eq!(uuid[8] & 0xc0, 0x80);
+    }
+
+    #[test]
+    fn uuid_v4_validation_rejects_zero_wrong_version_and_wrong_variant() {
+        let zero = [0_u8; 16];
+        assert!(!is_uuid_v4(&zero));
+
+        let mut uuid = new_uuid_v4();
+        uuid[6] = (uuid[6] & 0x0f) | 0x30;
+        assert!(!is_uuid_v4(&uuid));
+
+        let mut uuid = new_uuid_v4();
+        uuid[8] &= 0x3f;
+        assert!(!is_uuid_v4(&uuid));
+    }
+}


### PR DESCRIPTION
## Summary
- add an internal UUID helper module for v4 generation and validation
- route CLI UUID parsing/generation and chat-message transport validation through the shared helper
- add regression tests for UUID v4 bit and rejection behavior

## Verification
- git diff --check
- cargo check
- RUST_MIN_STACK=16777216 cargo test

Note: cargo fmt, rustfmt, and cargo clippy are unavailable in this checkout.

Closes #72