### PR TITLE
refactor: centralize fixed-size hex helpers

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -2,7 +2,7 @@ use super::{
     args::*,
     output::{write_contact, write_contact_header, write_history_message, write_peer_list},
     parse::{
-        fingerprint_hex, hex_value, load_local_identity, load_peer_identity,
+        fingerprint_hex, load_local_identity, load_peer_identity,
         load_peer_identity_from_fingerprint, open_storage, parse_fingerprint, parse_hash,
         parse_uuid, read_file, require_ipv4, uuid_hex, validate_cli_contact_alias, write_file,
     },
@@ -609,14 +609,15 @@ pub(super) fn run_contact_trust<W: Write>(
 }
 
 fn find_contact(storage: &Storage, query: &str) -> Result<ContactRecord, CliError> {
-    if query.len() == 64 && query.bytes().all(|byte| hex_value(byte).is_some()) {
-        let fingerprint = parse_fingerprint(query)?;
-        return storage
-            .get_contact_by_fingerprint(fingerprint)
-            .map_err(CliError::ReadContacts)?
-            .ok_or_else(|| CliError::MissingContact {
-                query: query.to_owned(),
-            });
+    if query.len() == 64 {
+        if let Ok(fingerprint) = parse_fingerprint(query) {
+            return storage
+                .get_contact_by_fingerprint(fingerprint)
+                .map_err(CliError::ReadContacts)?
+                .ok_or_else(|| CliError::MissingContact {
+                    query: query.to_owned(),
+                });
+        }
     }
 
     validate_cli_contact_alias(query.to_owned())?;

--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -3,6 +3,7 @@ use crate::{
     config::Config,
     crypto::{self, public_key_to_bytes},
     discovery::Fingerprint,
+    hex,
     message_transport::{LocalChatIdentity, PeerChatIdentity},
     storage::Storage,
     uuid,
@@ -34,7 +35,7 @@ pub(super) fn require_ipv4(field: &'static str, value: IpAddr) -> Result<Ipv4Add
 }
 
 pub(super) fn parse_fingerprint(input: &str) -> Result<Fingerprint, CliError> {
-    parse_fixed_hex::<32>(input).map_err(CliError::InvalidFingerprint)
+    hex::parse_fixed_hex(input).map_err(CliError::InvalidFingerprint)
 }
 
 pub(super) fn validate_cli_contact_alias(alias: String) -> Result<String, CliError> {
@@ -51,45 +52,21 @@ pub(super) fn validate_cli_contact_alias(alias: String) -> Result<String, CliErr
 }
 
 pub(super) fn parse_hash(input: &str) -> Result<[u8; 32], CliError> {
-    parse_fixed_hex::<32>(input).map_err(CliError::InvalidMessageHash)
+    hex::parse_fixed_hex(input).map_err(CliError::InvalidMessageHash)
 }
 
 pub(super) fn parse_uuid(input: &str) -> Result<[u8; 16], CliError> {
-    let mut hex = String::with_capacity(32);
-    for byte in input.bytes() {
-        if byte != b'-' {
-            hex.push(byte as char);
-        }
-    }
-    if hex.len() != 32 {
-        return Err(CliError::InvalidConversationUuid(
-            "expected 32 hex characters or a hyphenated UUID".to_owned(),
-        ));
-    }
-
-    let uuid = parse_fixed_hex::<16>(&hex).map_err(CliError::InvalidConversationUuid)?;
+    let uuid = hex::parse_hyphenated_fixed_hex(
+        input,
+        "expected 32 hex characters or a hyphenated UUID",
+    )
+    .map_err(CliError::InvalidConversationUuid)?;
     if !uuid::is_uuid_v4(&uuid) {
         return Err(CliError::InvalidConversationUuid(
             "expected a non-zero UUID v4".to_owned(),
         ));
     }
     Ok(uuid)
-}
-
-fn parse_fixed_hex<const N: usize>(input: &str) -> Result<[u8; N], String> {
-    if input.len() != N * 2 {
-        return Err(format!("expected exactly {} hex characters", N * 2));
-    }
-
-    let mut out = [0_u8; N];
-    for (index, chunk) in input.as_bytes().chunks_exact(2).enumerate() {
-        let high = hex_value(chunk[0])
-            .ok_or_else(|| format!("invalid hex character at byte {}", index * 2))?;
-        let low = hex_value(chunk[1])
-            .ok_or_else(|| format!("invalid hex character at byte {}", index * 2 + 1))?;
-        out[index] = (high << 4) | low;
-    }
-    Ok(out)
 }
 
 pub(super) fn load_local_identity(path: &PathBuf) -> Result<LocalChatIdentity, CliError> {
@@ -169,37 +146,10 @@ pub(super) fn write_file(path: &PathBuf, bytes: &[u8]) -> Result<(), CliError> {
     })
 }
 
-pub(super) fn hex_value(byte: u8) -> Option<u8> {
-    match byte {
-        b'0'..=b'9' => Some(byte - b'0'),
-        b'a'..=b'f' => Some(byte - b'a' + 10),
-        b'A'..=b'F' => Some(byte - b'A' + 10),
-        _ => None,
-    }
-}
-
 pub(super) fn fingerprint_hex(fingerprint: &Fingerprint) -> String {
-    let mut output = String::with_capacity(64);
-    for byte in fingerprint {
-        output.push(nibble_hex(byte >> 4));
-        output.push(nibble_hex(byte & 0x0f));
-    }
-    output
+    hex::lower_hex(fingerprint)
 }
 
 pub(super) fn uuid_hex(uuid: &[u8; 16]) -> String {
-    let mut output = String::with_capacity(32);
-    for byte in uuid {
-        output.push(nibble_hex(byte >> 4));
-        output.push(nibble_hex(byte & 0x0f));
-    }
-    output
-}
-
-fn nibble_hex(value: u8) -> char {
-    match value {
-        0..=9 => (b'0' + value) as char,
-        10..=15 => (b'a' + value - 10) as char,
-        _ => unreachable!("nibble value is always <= 15"),
-    }
+    hex::lower_hex(uuid)
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,0 +1,101 @@
+pub(crate) fn parse_fixed_hex<const N: usize>(input: &str) -> Result<[u8; N], String> {
+    if input.len() != N * 2 {
+        return Err(format!("expected exactly {} hex characters", N * 2));
+    }
+
+    let mut out = [0_u8; N];
+    for (index, chunk) in input.as_bytes().chunks_exact(2).enumerate() {
+        let high = hex_value(chunk[0])
+            .ok_or_else(|| format!("invalid hex character at byte {}", index * 2))?;
+        let low = hex_value(chunk[1])
+            .ok_or_else(|| format!("invalid hex character at byte {}", index * 2 + 1))?;
+        out[index] = (high << 4) | low;
+    }
+    Ok(out)
+}
+
+pub(crate) fn parse_hyphenated_fixed_hex<const N: usize>(
+    input: &str,
+    length_error: impl Into<String>,
+) -> Result<[u8; N], String> {
+    let mut hex = String::with_capacity(N * 2);
+    for byte in input.bytes() {
+        if byte != b'-' {
+            hex.push(byte as char);
+        }
+    }
+    if hex.len() != N * 2 {
+        return Err(length_error.into());
+    }
+
+    parse_fixed_hex(&hex)
+}
+
+pub(crate) fn lower_hex<const N: usize>(bytes: &[u8; N]) -> String {
+    let mut output = String::with_capacity(N * 2);
+    for byte in bytes {
+        output.push(nibble_hex(byte >> 4));
+        output.push(nibble_hex(byte & 0x0f));
+    }
+    output
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn nibble_hex(value: u8) -> char {
+    match value {
+        0..=9 => (b'0' + value) as char,
+        10..=15 => (b'a' + value - 10) as char,
+        _ => unreachable!("nibble value is always <= 15"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_hex_accepts_lowercase_and_uppercase() {
+        assert_eq!(
+            parse_fixed_hex::<4>("00aF10BC").expect("valid hex"),
+            [0x00, 0xaf, 0x10, 0xbc]
+        );
+    }
+
+    #[test]
+    fn fixed_hex_rejects_wrong_lengths_and_invalid_digits() {
+        assert_eq!(
+            parse_fixed_hex::<2>("000").expect_err("wrong length"),
+            "expected exactly 4 hex characters"
+        );
+        assert_eq!(
+            parse_fixed_hex::<2>("0g00").expect_err("invalid digit"),
+            "invalid hex character at byte 1"
+        );
+    }
+
+    #[test]
+    fn hyphenated_fixed_hex_strips_hyphens_before_parsing() {
+        assert_eq!(
+            parse_hyphenated_fixed_hex::<4>("00-af-10-bc", "bad length").expect("valid hex"),
+            [0x00, 0xaf, 0x10, 0xbc]
+        );
+        assert_eq!(
+            parse_hyphenated_fixed_hex::<4>("00-af-10", "bad length")
+                .expect_err("wrong length"),
+            "bad length"
+        );
+    }
+
+    #[test]
+    fn lower_hex_formats_lowercase() {
+        assert_eq!(lower_hex(&[0x00, 0xaf, 0x10, 0xbc]), "00af10bc");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod conversation_engine;
 pub mod crypto;
 pub mod discovery;
+mod hex;
 pub mod key_exchange;
 pub mod message_transport;
 pub mod storage;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,4 @@
-use crate::{discovery::Fingerprint, time};
+use crate::{discovery::Fingerprint, hex, time};
 use rusqlite::{params, Connection, OptionalExtension};
 use std::{
     collections::{HashMap, HashSet},
@@ -998,50 +998,11 @@ fn reply_reference_from_headers(headers: &[u8]) -> Option<ReplyReference> {
 }
 
 fn parse_uuid(input: &str) -> Option<[u8; 16]> {
-    let mut hex = String::with_capacity(32);
-    for byte in input.bytes() {
-        if byte == b'-' {
-            continue;
-        }
-        hex.push(byte as char);
-    }
-    if hex.len() != 32 {
-        return None;
-    }
-
-    let mut out = [0; 16];
-    for (index, chunk) in hex.as_bytes().chunks_exact(2).enumerate() {
-        out[index] = parse_hex_byte(chunk)?;
-    }
-    Some(out)
+    hex::parse_hyphenated_fixed_hex(input, "expected 32 hex characters").ok()
 }
 
 fn parse_hash(input: &str) -> Option<[u8; 32]> {
-    if input.len() != 64 {
-        return None;
-    }
-
-    let mut out = [0; 32];
-    for (index, chunk) in input.as_bytes().chunks_exact(2).enumerate() {
-        out[index] = parse_hex_byte(chunk)?;
-    }
-    Some(out)
-}
-
-fn parse_hex_byte(input: &[u8]) -> Option<u8> {
-    let [high, low] = input else {
-        return None;
-    };
-    Some(hex_value(*high)? << 4 | hex_value(*low)?)
-}
-
-fn hex_value(byte: u8) -> Option<u8> {
-    match byte {
-        b'0'..=b'9' => Some(byte - b'0'),
-        b'a'..=b'f' => Some(byte - b'a' + 10),
-        b'A'..=b'F' => Some(byte - b'A' + 10),
-        _ => None,
-    }
+    hex::parse_fixed_hex(input).ok()
 }
 
 fn order_message_chain(
@@ -1138,20 +1099,7 @@ fn unix_timestamp() -> Result<i64, StorageError> {
 }
 
 fn fingerprint_hex(fingerprint: &Fingerprint) -> String {
-    let mut output = String::with_capacity(64);
-    for byte in fingerprint {
-        output.push(nibble_hex(byte >> 4));
-        output.push(nibble_hex(byte & 0x0f));
-    }
-    output
-}
-
-fn nibble_hex(value: u8) -> char {
-    match value {
-        0..=9 => (b'0' + value) as char,
-        10..=15 => (b'a' + value - 10) as char,
-        _ => unreachable!("nibble value is always <= 15"),
-    }
+    hex::lower_hex(fingerprint)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add a private shared hex helper module for fixed-size parsing, hyphen-stripped UUID parsing, and lowercase formatting
- route CLI fingerprint/hash/UUID parsing and output formatting through the shared helpers
- route storage reply metadata parsing and fingerprint conflict formatting through the shared helpers

## Verification
- git diff --check
- cargo check
- RUST_MIN_STACK=16777216 cargo test

Note: cargo fmt and cargo clippy are unavailable in this checkout.

Closes #74