### PR TITLE
refactor: consolidate storage byte-array conversions

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1076,22 +1076,25 @@ fn storage_error_to_sql_error(error: StorageError) -> rusqlite::Error {
     )
 }
 
+fn vec_to_fixed_array<const N: usize>(
+    bytes: Vec<u8>,
+    invalid_length: impl FnOnce(usize) -> StorageError,
+) -> Result<[u8; N], StorageError> {
+    bytes
+        .try_into()
+        .map_err(|bytes: Vec<u8>| invalid_length(bytes.len()))
+}
+
 fn vec_to_message_uuid(bytes: Vec<u8>) -> Result<[u8; 16], StorageError> {
-    bytes.try_into().map_err(|bytes: Vec<u8>| {
-        StorageError::InvalidMessageUuidLength { len: bytes.len() }
-    })
+    vec_to_fixed_array(bytes, |len| StorageError::InvalidMessageUuidLength { len })
 }
 
 fn vec_to_message_hash(bytes: Vec<u8>) -> Result<[u8; 32], StorageError> {
-    bytes.try_into().map_err(|bytes: Vec<u8>| {
-        StorageError::InvalidMessageHashLength { len: bytes.len() }
-    })
+    vec_to_fixed_array(bytes, |len| StorageError::InvalidMessageHashLength { len })
 }
 
 fn vec_to_fingerprint(bytes: Vec<u8>) -> Result<Fingerprint, StorageError> {
-    bytes
-        .try_into()
-        .map_err(|bytes: Vec<u8>| StorageError::InvalidFingerprintLength { len: bytes.len() })
+    vec_to_fixed_array(bytes, |len| StorageError::InvalidFingerprintLength { len })
 }
 
 fn unix_timestamp() -> Result<i64, StorageError> {


### PR DESCRIPTION
## Summary
- add a private const-generic helper for SQLite BLOB to fixed-size byte-array conversion
- keep the message UUID, message hash, and fingerprint wrapper helpers so row mapping remains domain-specific
- preserve the existing `StorageError` variants for invalid stored BLOB lengths

## Verification
- git diff --check
- cargo check
- RUST_MIN_STACK=16777216 cargo test

Note: cargo fmt and cargo clippy are unavailable in this checkout.

Closes #76
